### PR TITLE
Remove automatic Git hook setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,4 @@ CONTRIBUTING
 ============
 
 LightSaml is an open source project and is open for contributions.
-
-
+Run `contrib/setup.sh` to setup a Git commit hook to ensure a consistent code style.

--- a/composer.json
+++ b/composer.json
@@ -43,13 +43,6 @@
         "lightsaml/symfony-bridge": "Symfony 2 build container bridge",
         "lightsaml/sp-bundle": "Symfony 2 SP security bundle"
     },
-    "scripts": {
-        "post-install-cmd": [
-            "bash contrib/setup.sh"
-        ],
-        "post-update-cmd": [
-        ]
-    },
     "config": {
         "bin-dir": "bin"
     },


### PR DESCRIPTION
Even tough I completely understand the need for a consistent coding style, the current approach seems to be a bit invasive to me. I generally don't like it if someone fiddles with my Git configuration. Therefore I would be glad to see this getting merged.

In case you approve this change, it could be applied to the other packages (`SpBundle`, ...) as well.
