### PR TITLE
Update xmlseclibs to v2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "php": ">=5.5.1",
-        "robrichards/xmlseclibs": "1.3.2",
+        "robrichards/xmlseclibs": "~2.0",
         "symfony/console": "~2.3",
         "symfony/http-foundation": "~2.3",
         "symfony/event-dispatcher": "~2.3"

--- a/doc/signing_and_certificates.md
+++ b/doc/signing_and_certificates.md
@@ -1,7 +1,7 @@
 SIGNING AND CERTIFICATES
 ========================
 
-The LightSaml relies on the [xmlseclibs](https://code.google.com/p/xmlseclibs/) regarding signing and certificates
+The LightSaml relies on the [xmlseclibs](https://github.com/robrichards/xmlseclibs) regarding signing and certificates
 functionality. LightSaml has helper methods and was tested using xmlseclibs with PEM format only.
 
 

--- a/src/LightSaml/Binding/HttpRedirectBinding.php
+++ b/src/LightSaml/Binding/HttpRedirectBinding.php
@@ -19,6 +19,7 @@ use LightSaml\Model\Protocol\SamlMessage;
 use LightSaml\Model\XmlDSig\SignatureWriter;
 use LightSaml\Model\XmlDSig\SignatureStringReader;
 use LightSaml\SamlConstants;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -221,7 +222,7 @@ class HttpRedirectBinding extends AbstractBinding
      */
     protected function addSignatureToUrl(&$msg, SignatureWriter $signature = null)
     {
-        /** @var $key \XMLSecurityKey */
+        /** @var $key XMLSecurityKey */
         $key = $signature ? $signature->getXmlSecurityKey() : null;
 
         if (null != $key) {

--- a/src/LightSaml/Credential/AbstractCredential.php
+++ b/src/LightSaml/Credential/AbstractCredential.php
@@ -12,6 +12,7 @@
 namespace LightSaml\Credential;
 
 use LightSaml\Credential\Context\CredentialContextSet;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 abstract class AbstractCredential implements CredentialInterface
 {
@@ -24,10 +25,10 @@ abstract class AbstractCredential implements CredentialInterface
     /** @var  string[] */
     private $keyNames = array();
 
-    /** @var  \XMLSecurityKey|null */
+    /** @var  XMLSecurityKey|null */
     private $publicKey;
 
-    /** @var  \XMLSecurityKey|null */
+    /** @var  XMLSecurityKey|null */
     private $privateKey;
 
     /** @var  string|null */
@@ -68,7 +69,7 @@ abstract class AbstractCredential implements CredentialInterface
     }
 
     /**
-     * @return \XMLSecurityKey|null
+     * @return XMLSecurityKey|null
      */
     public function getPublicKey()
     {
@@ -76,7 +77,7 @@ abstract class AbstractCredential implements CredentialInterface
     }
 
     /**
-     * @return \XMLSecurityKey|null
+     * @return XMLSecurityKey|null
      */
     public function getPrivateKey()
     {
@@ -151,11 +152,11 @@ abstract class AbstractCredential implements CredentialInterface
     }
 
     /**
-     * @param null|\XMLSecurityKey $privateKey
+     * @param null|XMLSecurityKey $privateKey
      *
      * @return AbstractCredential
      */
-    public function setPrivateKey(\XMLSecurityKey $privateKey)
+    public function setPrivateKey(XMLSecurityKey $privateKey)
     {
         $this->privateKey = $privateKey;
 
@@ -163,11 +164,11 @@ abstract class AbstractCredential implements CredentialInterface
     }
 
     /**
-     * @param null|\XMLSecurityKey $publicKey
+     * @param null|XMLSecurityKey $publicKey
      *
      * @return AbstractCredential
      */
-    public function setPublicKey(\XMLSecurityKey $publicKey)
+    public function setPublicKey(XMLSecurityKey $publicKey)
     {
         $this->publicKey = $publicKey;
 

--- a/src/LightSaml/Credential/CredentialInterface.php
+++ b/src/LightSaml/Credential/CredentialInterface.php
@@ -12,6 +12,7 @@
 namespace LightSaml\Credential;
 
 use LightSaml\Credential\Context\CredentialContextSet;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 interface CredentialInterface
 {
@@ -33,12 +34,12 @@ interface CredentialInterface
     public function getKeyNames();
 
     /**
-     * @return \XMLSecurityKey|null
+     * @return XMLSecurityKey|null
      */
     public function getPublicKey();
 
     /**
-     * @return \XMLSecurityKey|null
+     * @return XMLSecurityKey|null
      */
     public function getPrivateKey();
 

--- a/src/LightSaml/Credential/KeyHelper.php
+++ b/src/LightSaml/Credential/KeyHelper.php
@@ -12,6 +12,7 @@
 namespace LightSaml\Credential;
 
 use LightSaml\Error\LightSamlSecurityException;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 class KeyHelper
 {
@@ -21,11 +22,11 @@ class KeyHelper
      * @param bool   $isFile     true if $key is a filename of the key
      * @param string $type
      *
-     * @return \XMLSecurityKey
+     * @return XMLSecurityKey
      */
-    public static function createPrivateKey($key, $passphrase, $isFile = false, $type = \XMLSecurityKey::RSA_SHA1)
+    public static function createPrivateKey($key, $passphrase, $isFile = false, $type = XMLSecurityKey::RSA_SHA1)
     {
-        $result = new \XMLSecurityKey($type, array('type' => 'private'));
+        $result = new XMLSecurityKey($type, array('type' => 'private'));
         $result->passphrase = $passphrase;
         $result->loadKey($key, $isFile, false);
 
@@ -35,29 +36,29 @@ class KeyHelper
     /**
      * @param X509Certificate $certificate
      *
-     * @return \XMLSecurityKey
+     * @return XMLSecurityKey
      */
     public static function createPublicKey(X509Certificate $certificate)
     {
         if (null == $certificate->getSignatureAlgorithm()) {
             throw new LightSamlSecurityException('Unrecognized certificate signature algorithm');
         }
-        $key = new \XMLSecurityKey($certificate->getSignatureAlgorithm(), array('type' => 'public'));
+        $key = new XMLSecurityKey($certificate->getSignatureAlgorithm(), array('type' => 'public'));
         $key->loadKey($certificate->toPem(), false, true);
 
         return $key;
     }
 
     /**
-     * @param \XMLSecurityKey $key
-     * @param string          $algorithm
+     * @param XMLSecurityKey $key
+     * @param string         $algorithm
      *
      * @throws \LightSaml\Error\LightSamlSecurityException
      * @throws \InvalidArgumentException
      *
-     * @return \XMLSecurityKey
+     * @return XMLSecurityKey
      */
-    public static function castKey(\XMLSecurityKey $key, $algorithm)
+    public static function castKey(XMLSecurityKey $key, $algorithm)
     {
         if (false == is_string($algorithm)) {
             throw new \InvalidArgumentException('Algorithm must be string');
@@ -76,7 +77,7 @@ class KeyHelper
             throw new LightSamlSecurityException('Missing key in public key details.');
         }
 
-        $newKey = new \XMLSecurityKey($algorithm, array('type' => 'public'));
+        $newKey = new XMLSecurityKey($algorithm, array('type' => 'public'));
         $newKey->loadKey($keyInfo['key']);
 
         return $newKey;

--- a/src/LightSaml/Credential/X509Certificate.php
+++ b/src/LightSaml/Credential/X509Certificate.php
@@ -14,6 +14,7 @@ namespace LightSaml\Credential;
 use LightSaml\Error\LightSamlException;
 use LightSaml\Error\LightSamlSecurityException;
 use LightSaml\SamlConstants;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 class X509Certificate
 {
@@ -121,19 +122,19 @@ class X509Certificate
             switch ($match[1]) {
                 case 'sha1WithRSAEncryption':
                 case 'sha1WithRSA':
-                    $this->signatureAlgorithm = \XMLSecurityKey::RSA_SHA1;
+                    $this->signatureAlgorithm = XMLSecurityKey::RSA_SHA1;
                     break;
                 case 'sha256WithRSAEncryption':
                 case 'sha256WithRSA':
-                    $this->signatureAlgorithm = \XMLSecurityKey::RSA_SHA256;
+                    $this->signatureAlgorithm = XMLSecurityKey::RSA_SHA256;
                     break;
                 case 'sha384WithRSAEncryption':
                 case 'sha384WithRSA':
-                    $this->signatureAlgorithm = \XMLSecurityKey::RSA_SHA384;
+                    $this->signatureAlgorithm = XMLSecurityKey::RSA_SHA384;
                     break;
                 case 'sha512WithRSAEncryption':
                 case 'sha512WithRSA':
-                    $this->signatureAlgorithm = \XMLSecurityKey::RSA_SHA512;
+                    $this->signatureAlgorithm = XMLSecurityKey::RSA_SHA512;
                     break;
                 case 'md5WithRSAEncryption':
                 case 'md5WithRSA':
@@ -240,7 +241,7 @@ class X509Certificate
             throw new LightSamlException('Certificate data not set');
         }
 
-        return \XMLSecurityKey::getRawThumbprint($this->toPem());
+        return XMLSecurityKey::getRawThumbprint($this->toPem());
     }
 
     public function getSignatureAlgorithm()

--- a/src/LightSaml/Credential/X509Credential.php
+++ b/src/LightSaml/Credential/X509Credential.php
@@ -11,6 +11,8 @@
 
 namespace LightSaml\Credential;
 
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+
 class X509Credential extends AbstractCredential implements X509CredentialInterface
 {
     /** @var  X509Certificate */
@@ -18,9 +20,9 @@ class X509Credential extends AbstractCredential implements X509CredentialInterfa
 
     /**
      * @param X509Certificate $certificate
-     * @param \XMLSecurityKey $privateKey
+     * @param XMLSecurityKey  $privateKey
      */
-    public function __construct(X509Certificate $certificate, \XMLSecurityKey $privateKey = null)
+    public function __construct(X509Certificate $certificate, XMLSecurityKey $privateKey = null)
     {
         parent::__construct();
         $this->certificate = $certificate;

--- a/src/LightSaml/Model/Assertion/EncryptedAssertionReader.php
+++ b/src/LightSaml/Model/Assertion/EncryptedAssertionReader.php
@@ -12,11 +12,12 @@
 namespace LightSaml\Model\Assertion;
 
 use LightSaml\Model\Context\DeserializationContext;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 class EncryptedAssertionReader extends EncryptedElementReader
 {
     /**
-     * @param \XMLSecurityKey[]      $inputKeys
+     * @param XMLSecurityKey[]       $inputKeys
      * @param DeserializationContext $deserializationContext
      *
      * @return Assertion
@@ -29,7 +30,7 @@ class EncryptedAssertionReader extends EncryptedElementReader
     }
 
     /**
-     * @param \XMLSecurityKey        $credential
+     * @param XMLSecurityKey         $credential
      * @param DeserializationContext $deserializationContext
      *
      * @return Assertion

--- a/src/LightSaml/Model/Assertion/EncryptedElementReader.php
+++ b/src/LightSaml/Model/Assertion/EncryptedElementReader.php
@@ -16,20 +16,22 @@ use LightSaml\Model\Context\DeserializationContext;
 use LightSaml\Model\Context\SerializationContext;
 use LightSaml\Error\LightSamlSecurityException;
 use LightSaml\Error\LightSamlXmlException;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use RobRichards\XMLSecLibs\XMLSecEnc;
 
 class EncryptedElementReader extends EncryptedElement
 {
-    /** @var \XMLSecEnc */
+    /** @var XMLSecEnc */
     protected $xmlEnc;
 
-    /** @var  \XMLSecurityKey */
+    /** @var  XMLSecurityKey */
     protected $symmetricKey;
 
-    /** @var  \XMLSecurityKey */
+    /** @var  XMLSecurityKey */
     protected $symmetricKeyInfo;
 
     /**
-     * @return \XMLSecurityKey
+     * @return XMLSecurityKey
      */
     public function getSymmetricKey()
     {
@@ -37,7 +39,7 @@ class EncryptedElementReader extends EncryptedElement
     }
 
     /**
-     * @return \XMLSecurityKey
+     * @return XMLSecurityKey
      */
     public function getSymmetricKeyInfo()
     {
@@ -77,7 +79,7 @@ class EncryptedElementReader extends EncryptedElement
 
         /** @var \DOMElement $encryptedData */
         $encryptedData = $list->item(0);
-        $this->xmlEnc = new \XMLSecEnc();
+        $this->xmlEnc = new XMLSecEnc();
         $this->xmlEnc->setNode($encryptedData);
         $this->xmlEnc->type = $encryptedData->getAttribute('Type');
 
@@ -87,7 +89,7 @@ class EncryptedElementReader extends EncryptedElement
     }
 
     /**
-     * @param \XMLSecurityKey[] $inputKeys
+     * @param XMLSecurityKey[] $inputKeys
      *
      * @throws \LogicException
      * @throws \LightSaml\Error\LightSamlXmlException
@@ -104,7 +106,7 @@ class EncryptedElementReader extends EncryptedElement
             if ($key instanceof CredentialInterface) {
                 $key = $key->getPrivateKey();
             }
-            if (false == $key instanceof \XMLSecurityKey) {
+            if (false == $key instanceof XMLSecurityKey) {
                 throw new \InvalidArgumentException('Expected XMLSecurityKey');
             }
 
@@ -123,7 +125,7 @@ class EncryptedElementReader extends EncryptedElement
     }
 
     /**
-     * @param \XMLSecurityKey $inputKey
+     * @param XMLSecurityKey $inputKey
      *
      * @throws \LogicException
      * @throws \LightSaml\Error\LightSamlXmlException
@@ -131,7 +133,7 @@ class EncryptedElementReader extends EncryptedElement
      *
      * @return \DOMElement
      */
-    public function decrypt(\XMLSecurityKey $inputKey)
+    public function decrypt(XMLSecurityKey $inputKey)
     {
         $this->symmetricKey = $this->loadSymmetricKey();
         $this->symmetricKeyInfo = $this->loadSymmetricKeyInfo($this->symmetricKey);
@@ -199,23 +201,23 @@ class EncryptedElementReader extends EncryptedElement
     }
 
     /**
-     * @param \XMLSecurityKey $inputKey
+     * @param XMLSecurityKey $inputKey
      *
      * @throws \Exception
      */
-    protected function decryptSymmetricKey(\XMLSecurityKey $inputKey)
+    protected function decryptSymmetricKey(XMLSecurityKey $inputKey)
     {
         $inputKeyAlgo = $inputKey->getAlgorith();
-        if ($this->symmetricKeyInfo->getAlgorith() === \XMLSecurityKey::RSA_OAEP_MGF1P &&
-            ($inputKeyAlgo === \XMLSecurityKey::RSA_1_5 || $inputKeyAlgo === \XMLSecurityKey::RSA_SHA1)) {
+        if ($this->symmetricKeyInfo->getAlgorith() === XMLSecurityKey::RSA_OAEP_MGF1P &&
+            ($inputKeyAlgo === XMLSecurityKey::RSA_1_5 || $inputKeyAlgo === XMLSecurityKey::RSA_SHA1)) {
             // The RSA key formats are equal, so loading an RSA_1_5 key into an RSA_OAEP_MGF1P key can be done without problems.
             // We therefore pretend that the input key is an RSA_OAEP_MGF1P key.
-            $inputKeyAlgo = \XMLSecurityKey::RSA_OAEP_MGF1P;
+            $inputKeyAlgo = XMLSecurityKey::RSA_OAEP_MGF1P;
         }
 
         $this->checkInputAndMessageKeyAlgoSame($inputKeyAlgo, $this->symmetricKeyInfo->getAlgorith());
 
-        /** @var \XMLSecEnc $encKey */
+        /** @var XMLSecEnc $encKey */
         $encKey = $this->symmetricKeyInfo->encryptedCtx;
         $this->symmetricKeyInfo->key = $inputKey->key;
 
@@ -265,7 +267,7 @@ class EncryptedElementReader extends EncryptedElement
     }
 
     /**
-     * @return \XMLSecurityKey
+     * @return XMLSecurityKey
      *
      * @throws \LightSaml\Error\LightSamlXmlException
      */
@@ -280,13 +282,13 @@ class EncryptedElementReader extends EncryptedElement
     }
 
     /**
-     * @param \XMLSecurityKey $symmetricKey
+     * @param XMLSecurityKey $symmetricKey
      *
      * @throws \LightSaml\Error\LightSamlXmlException
      *
-     * @return \XMLSecurityKey
+     * @return XMLSecurityKey
      */
-    protected function loadSymmetricKeyInfo(\XMLSecurityKey $symmetricKey)
+    protected function loadSymmetricKeyInfo(XMLSecurityKey $symmetricKey)
     {
         $symmetricKeyInfo = $this->xmlEnc->locateKeyInfo($symmetricKey);
         if (false == $symmetricKeyInfo) {

--- a/src/LightSaml/Model/Assertion/EncryptedElementWriter.php
+++ b/src/LightSaml/Model/Assertion/EncryptedElementWriter.php
@@ -15,6 +15,8 @@ use LightSaml\Model\Context\DeserializationContext;
 use LightSaml\Model\Context\SerializationContext;
 use LightSaml\Error\LightSamlException;
 use LightSaml\Model\AbstractSamlModel;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use RobRichards\XMLSecLibs\XMLSecEnc;
 
 abstract class EncryptedElementWriter extends EncryptedElement
 {
@@ -23,34 +25,34 @@ abstract class EncryptedElementWriter extends EncryptedElement
 
     /**
      * @param AbstractSamlModel $object
-     * @param \XMLSecurityKey   $key
+     * @param XMLSecurityKey    $key
      *
      * @return SerializationContext
      */
-    public function encrypt(AbstractSamlModel $object, \XMLSecurityKey $key)
+    public function encrypt(AbstractSamlModel $object, XMLSecurityKey $key)
     {
         $serializationContext = new SerializationContext();
         $object->serialize($serializationContext->getDocument(), $serializationContext);
 
-        $enc = new \XMLSecEnc();
+        $enc = new XMLSecEnc();
         $enc->setNode($serializationContext->getDocument()->firstChild);
-        $enc->type = \XMLSecEnc::Element;
+        $enc->type = XMLSecEnc::Element;
 
         switch ($key->type) {
-            case \XMLSecurityKey::TRIPLEDES_CBC:
-            case \XMLSecurityKey::AES128_CBC:
-            case \XMLSecurityKey::AES192_CBC:
-            case \XMLSecurityKey::AES256_CBC:
+            case XMLSecurityKey::TRIPLEDES_CBC:
+            case XMLSecurityKey::AES128_CBC:
+            case XMLSecurityKey::AES192_CBC:
+            case XMLSecurityKey::AES256_CBC:
                 $symmetricKey = $key;
                 break;
 
-            case \XMLSecurityKey::RSA_1_5:
-            case \XMLSecurityKey::RSA_SHA1:
-            case \XMLSecurityKey::RSA_SHA256:
-            case \XMLSecurityKey::RSA_SHA384:
-            case \XMLSecurityKey::RSA_SHA512:
-            case \XMLSecurityKey::RSA_OAEP_MGF1P:
-                $symmetricKey = new \XMLSecurityKey(\XMLSecurityKey::AES128_CBC);
+            case XMLSecurityKey::RSA_1_5:
+            case XMLSecurityKey::RSA_SHA1:
+            case XMLSecurityKey::RSA_SHA256:
+            case XMLSecurityKey::RSA_SHA384:
+            case XMLSecurityKey::RSA_SHA512:
+            case XMLSecurityKey::RSA_OAEP_MGF1P:
+                $symmetricKey = new XMLSecurityKey(XMLSecurityKey::AES128_CBC);
                 $symmetricKey->generateSessionKey();
 
                 $enc->encryptKey($key, $symmetricKey);

--- a/src/LightSaml/Model/Context/DeserializationContext.php
+++ b/src/LightSaml/Model/Context/DeserializationContext.php
@@ -12,6 +12,7 @@
 namespace LightSaml\Model\Context;
 
 use LightSaml\SamlConstants;
+use RobRichards\XMLSecLibs\XMLSecEnc;
 
 class DeserializationContext
 {
@@ -60,7 +61,7 @@ class DeserializationContext
             $this->xpath->registerNamespace('samlp', SamlConstants::NS_PROTOCOL);
             $this->xpath->registerNamespace('md', SamlConstants::NS_METADATA);
             $this->xpath->registerNamespace('ds', SamlConstants::NS_XMLDSIG);
-            $this->xpath->registerNamespace('xenc', \XMLSecEnc::XMLENCNS);
+            $this->xpath->registerNamespace('xenc', XMLSecEnc::XMLENCNS);
         }
 
         return $this->xpath;

--- a/src/LightSaml/Model/XmlDSig/AbstractSignatureReader.php
+++ b/src/LightSaml/Model/XmlDSig/AbstractSignatureReader.php
@@ -14,23 +14,24 @@ namespace LightSaml\Model\XmlDSig;
 use LightSaml\Credential\CredentialInterface;
 use LightSaml\Credential\KeyHelper;
 use LightSaml\Error\LightSamlSecurityException;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 abstract class AbstractSignatureReader extends Signature
 {
-    /** @var  \XMLSecurityKey|null */
+    /** @var  XMLSecurityKey|null */
     protected $key;
 
     /**
-     * @param \XMLSecurityKey $key
+     * @param XMLSecurityKey $key
      *
      * @return bool True if validated, False if validation was not performed
      *
      * @throws \LightSaml\Error\LightSamlSecurityException If validation fails
      */
-    abstract public function validate(\XMLSecurityKey $key);
+    abstract public function validate(XMLSecurityKey $key);
 
     /**
-     * @return \XMLSecurityKey|null
+     * @return XMLSecurityKey|null
      */
     public function getKey()
     {
@@ -83,11 +84,11 @@ abstract class AbstractSignatureReader extends Signature
     abstract public function getAlgorithm();
 
     /**
-     * @param \XMLSecurityKey $key
+     * @param XMLSecurityKey $key
      *
-     * @return \XMLSecurityKey
+     * @return XMLSecurityKey
      */
-    protected function castKeyIfNecessary(\XMLSecurityKey $key)
+    protected function castKeyIfNecessary(XMLSecurityKey $key)
     {
         $algorithm = $this->getAlgorithm();
         if ($algorithm != $key->type) {

--- a/src/LightSaml/Model/XmlDSig/SignatureStringReader.php
+++ b/src/LightSaml/Model/XmlDSig/SignatureStringReader.php
@@ -14,6 +14,7 @@ namespace LightSaml\Model\XmlDSig;
 use LightSaml\Error\LightSamlSecurityException;
 use LightSaml\Model\Context\DeserializationContext;
 use LightSaml\Model\Context\SerializationContext;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 class SignatureStringReader extends AbstractSignatureReader
 {
@@ -87,13 +88,13 @@ class SignatureStringReader extends AbstractSignatureReader
     }
 
     /**
-     * @param \XMLSecurityKey $key
+     * @param XMLSecurityKey $key
      *
      * @return bool True if validated, False if validation was not performed
      *
      * @throws LightSamlSecurityException If validation fails
      */
-    public function validate(\XMLSecurityKey $key)
+    public function validate(XMLSecurityKey $key)
     {
         if (null == $this->getSignature()) {
             return false;

--- a/src/LightSaml/Model/XmlDSig/SignatureWriter.php
+++ b/src/LightSaml/Model/XmlDSig/SignatureWriter.php
@@ -15,13 +15,15 @@ use LightSaml\Model\Context\DeserializationContext;
 use LightSaml\Model\Context\SerializationContext;
 use LightSaml\SamlConstants;
 use LightSaml\Credential\X509Certificate;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use RobRichards\XMLSecLibs\XMLSecurityDSig;
 
 class SignatureWriter extends Signature
 {
     /** @var string */
-    protected $canonicalMethod = \XMLSecurityDSig::EXC_C14N;
+    protected $canonicalMethod = XMLSecurityDSig::EXC_C14N;
 
-    /** @var \XMLSecurityKey */
+    /** @var XMLSecurityKey */
     protected $xmlSecurityKey;
 
     /** @var X509Certificate */
@@ -29,9 +31,9 @@ class SignatureWriter extends Signature
 
     /**
      * @param X509Certificate|null $certificate
-     * @param \XMLSecurityKey|null $xmlSecurityKey
+     * @param XMLSecurityKey|null  $xmlSecurityKey
      */
-    public function __construct(X509Certificate $certificate = null, \XMLSecurityKey $xmlSecurityKey = null)
+    public function __construct(X509Certificate $certificate = null, XMLSecurityKey $xmlSecurityKey = null)
     {
         $this->certificate = $certificate;
         $this->xmlSecurityKey = $xmlSecurityKey;
@@ -58,11 +60,11 @@ class SignatureWriter extends Signature
     }
 
     /**
-     * @param \XMLSecurityKey $key
+     * @param XMLSecurityKey $key
      *
      * @return SignatureWriter
      */
-    public function setXmlSecurityKey(\XMLSecurityKey $key)
+    public function setXmlSecurityKey(XMLSecurityKey $key)
     {
         $this->xmlSecurityKey = $key;
 
@@ -70,7 +72,7 @@ class SignatureWriter extends Signature
     }
 
     /**
-     * @return \XMLSecurityKey
+     * @return XMLSecurityKey
      */
     public function getXmlSecurityKey()
     {
@@ -105,27 +107,27 @@ class SignatureWriter extends Signature
      */
     public function serialize(\DOMNode $parent, SerializationContext $context)
     {
-        $objXMLSecDSig = new \XMLSecurityDSig();
+        $objXMLSecDSig = new XMLSecurityDSig();
         $objXMLSecDSig->setCanonicalMethod($this->getCanonicalMethod());
         $key = $this->getXmlSecurityKey();
         switch ($key->type) {
-            case \XMLSecurityKey::RSA_SHA256:
-                $type = \XMLSecurityDSig::SHA256;
+            case XMLSecurityKey::RSA_SHA256:
+                $type = XMLSecurityDSig::SHA256;
                 break;
-            case \XMLSecurityKey::RSA_SHA384:
-                $type = \XMLSecurityDSig::SHA384;
+            case XMLSecurityKey::RSA_SHA384:
+                $type = XMLSecurityDSig::SHA384;
                 break;
-            case \XMLSecurityKey::RSA_SHA512:
-                $type = \XMLSecurityDSig::SHA512;
+            case XMLSecurityKey::RSA_SHA512:
+                $type = XMLSecurityDSig::SHA512;
                 break;
             default:
-                $type = \XMLSecurityDSig::SHA1;
+                $type = XMLSecurityDSig::SHA1;
         }
 
         $objXMLSecDSig->addReferenceList(
             array($parent),
             $type,
-            array(SamlConstants::XMLSEC_TRANSFORM_ALGORITHM_ENVELOPED_SIGNATURE, \XMLSecurityDSig::EXC_C14N),
+            array(SamlConstants::XMLSEC_TRANSFORM_ALGORITHM_ENVELOPED_SIGNATURE, XMLSecurityDSig::EXC_C14N),
             array('id_name' => $this->getIDName(), 'overwrite' => false)
         );
 

--- a/src/LightSaml/Model/XmlDSig/SignatureXmlReader.php
+++ b/src/LightSaml/Model/XmlDSig/SignatureXmlReader.php
@@ -16,10 +16,13 @@ use LightSaml\Error\LightSamlXmlException;
 use LightSaml\Model\Context\DeserializationContext;
 use LightSaml\Model\Context\SerializationContext;
 use LightSaml\SamlConstants;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use RobRichards\XMLSecLibs\XMLSecurityDSig;
+use RobRichards\XMLSecLibs\XMLSecEnc;
 
 class SignatureXmlReader extends AbstractSignatureReader
 {
-    /** @var \XMLSecurityDSig */
+    /** @var XMLSecurityDSig */
     protected $signature;
 
     /** @var string[] */
@@ -42,15 +45,15 @@ class SignatureXmlReader extends AbstractSignatureReader
     }
 
     /**
-     * @param \XMLSecurityDSig $signature
+     * @param XMLSecurityDSig $signature
      */
-    public function setSignature(\XMLSecurityDSig $signature)
+    public function setSignature(XMLSecurityDSig $signature)
     {
         $this->signature = $signature;
     }
 
     /**
-     * @return \XMLSecurityDSig
+     * @return XMLSecurityDSig
      */
     public function getSignature()
     {
@@ -58,13 +61,13 @@ class SignatureXmlReader extends AbstractSignatureReader
     }
 
     /**
-     * @param \XMLSecurityKey $key
+     * @param XMLSecurityKey $key
      *
      * @return bool
      *
      * @throws LightSamlSecurityException
      */
-    public function validate(\XMLSecurityKey $key)
+    public function validate(XMLSecurityKey $key)
     {
         if (null == $this->signature) {
             return false;
@@ -95,7 +98,7 @@ class SignatureXmlReader extends AbstractSignatureReader
             ? $this->signature->sigNode
             : $this->signature->sigNode->ownerDocument
         );
-        $xpath->registerNamespace('ds', \XMLSecurityDSig::XMLDSIGNS);
+        $xpath->registerNamespace('ds', XMLSecurityDSig::XMLDSIGNS);
 
         $list = $xpath->query('./ds:SignedInfo/ds:SignatureMethod', $this->signature->sigNode);
         if (!$list || $list->length == 0) {
@@ -132,14 +135,14 @@ class SignatureXmlReader extends AbstractSignatureReader
     {
         $this->checkXmlNodeName($node, 'Signature', SamlConstants::NS_XMLDSIG);
 
-        $this->signature = new \XMLSecurityDSig();
+        $this->signature = new XMLSecurityDSig();
         $this->signature->idKeys[] = $this->getIDName();
         $this->signature->sigNode = $node;
         $this->signature->canonicalizeSignedInfo();
 
         $this->key = null;
-        $key = new \XMLSecurityKey(\XMLSecurityKey::RSA_SHA1, array('type' => 'public'));
-        \XMLSecEnc::staticLocateKeyInfo($key, $node);
+        $key = new XMLSecurityKey(XMLSecurityKey::RSA_SHA1, array('type' => 'public'));
+        XMLSecEnc::staticLocateKeyInfo($key, $node);
         if ($key->name || $key->key) {
             $this->key = $key;
         }

--- a/tests/LightSaml/Tests/Action/Profile/Inbound/Response/DecryptAssertionsActionTest.php
+++ b/tests/LightSaml/Tests/Action/Profile/Inbound/Response/DecryptAssertionsActionTest.php
@@ -14,6 +14,7 @@ use LightSaml\Model\Protocol\Response;
 use LightSaml\Profile\Profiles;
 use LightSaml\Resolver\Credential\CredentialResolverQuery;
 use LightSaml\Tests\TestHelper;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 class DecryptAssertionsActionTest extends \PHPUnit_Framework_TestCase
 {
@@ -62,7 +63,7 @@ class DecryptAssertionsActionTest extends \PHPUnit_Framework_TestCase
 
         $credentialMock1->expects($this->any())
             ->method('getPrivateKey')
-            ->willReturn($privateKey = new \XMLSecurityKey(\XMLSecurityKey::TRIPLEDES_CBC));
+            ->willReturn($privateKey = new XMLSecurityKey(XMLSecurityKey::TRIPLEDES_CBC));
 
         $action->execute($context);
 

--- a/tests/LightSaml/Tests/Credential/Criteria/AlgorithmCriteriaTest.php
+++ b/tests/LightSaml/Tests/Credential/Criteria/AlgorithmCriteriaTest.php
@@ -4,6 +4,7 @@ namespace LightSaml\Tests\Credential\Criteria;
 
 use LightSaml\Credential\Criteria\AlgorithmCriteria;
 use LightSaml\Credential\Criteria\TrustCriteriaInterface;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 class AlgorithmCriteriaTest extends \PHPUnit_Framework_TestCase
 {
@@ -14,7 +15,7 @@ class AlgorithmCriteriaTest extends \PHPUnit_Framework_TestCase
 
     public function test_returns_value_given_to_constructor()
     {
-        $criteria = new AlgorithmCriteria($expectedValue = \XMLSecurityKey::AES256_CBC);
+        $criteria = new AlgorithmCriteria($expectedValue = XMLSecurityKey::AES256_CBC);
         $this->assertEquals($expectedValue, $criteria->getAlgorithm());
     }
 }

--- a/tests/LightSaml/Tests/Functional/Credential/X509CertificateTest.php
+++ b/tests/LightSaml/Tests/Functional/Credential/X509CertificateTest.php
@@ -4,6 +4,7 @@ namespace LightSaml\Tests\Functional\Credential;
 
 use LightSaml\Credential\X509Certificate;
 use LightSaml\SamlConstants;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 class X509CertificateTest extends \PHPUnit_Framework_TestCase
 {
@@ -17,25 +18,25 @@ class X509CertificateTest extends \PHPUnit_Framework_TestCase
     public function test_algorithm_sha1()
     {
         $certificate = X509Certificate::fromFile(__DIR__.'/../../../../../resources/sample/Certificate/saml-sha1.crt');
-        $this->assertEquals(\XMLSecurityKey::RSA_SHA1, $certificate->getSignatureAlgorithm());
+        $this->assertEquals(XMLSecurityKey::RSA_SHA1, $certificate->getSignatureAlgorithm());
     }
 
     public function test_algorithm_sha256()
     {
         $certificate = X509Certificate::fromFile(__DIR__.'/../../../../../resources/sample/Certificate/saml-sha256.crt');
-        $this->assertEquals(\XMLSecurityKey::RSA_SHA256, $certificate->getSignatureAlgorithm());
+        $this->assertEquals(XMLSecurityKey::RSA_SHA256, $certificate->getSignatureAlgorithm());
     }
 
     public function test_algorithm_sha384()
     {
         $certificate = X509Certificate::fromFile(__DIR__.'/../../../../../resources/sample/Certificate/saml-sha384.crt');
-        $this->assertEquals(\XMLSecurityKey::RSA_SHA384, $certificate->getSignatureAlgorithm());
+        $this->assertEquals(XMLSecurityKey::RSA_SHA384, $certificate->getSignatureAlgorithm());
     }
 
     public function test_algorithm_sha512()
     {
         $certificate = X509Certificate::fromFile(__DIR__.'/../../../../../resources/sample/Certificate/saml-sha512.crt');
-        $this->assertEquals(\XMLSecurityKey::RSA_SHA512, $certificate->getSignatureAlgorithm());
+        $this->assertEquals(XMLSecurityKey::RSA_SHA512, $certificate->getSignatureAlgorithm());
     }
 
     public function test_algorithm_md5()

--- a/tests/LightSaml/Tests/Resolver/Credential/CredentialResolverQueryTest.php
+++ b/tests/LightSaml/Tests/Resolver/Credential/CredentialResolverQueryTest.php
@@ -6,6 +6,7 @@ use LightSaml\Credential\CredentialInterface;
 use LightSaml\Criteria\CriteriaSet;
 use LightSaml\Resolver\Credential\CredentialResolverInterface;
 use LightSaml\Resolver\Credential\CredentialResolverQuery;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 class CredentialResolverQueryTest extends \PHPUnit_Framework_TestCase
 {
@@ -119,10 +120,10 @@ class CredentialResolverQueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\XMLSecurityKey
+     * @return \PHPUnit_Framework_MockObject_MockObject|XMLSecurityKey
      */
     private function getXmlSecurityKeyMock()
     {
-        return $this->getMock(\XMLSecurityKey::class, [], [], '', false);
+        return $this->getMock(XMLSecurityKey::class, [], [], '', false);
     }
 }

--- a/tests/LightSaml/Tests/Resolver/Credential/PrivateKeyResolverTest.php
+++ b/tests/LightSaml/Tests/Resolver/Credential/PrivateKeyResolverTest.php
@@ -6,6 +6,7 @@ use LightSaml\Credential\CredentialInterface;
 use LightSaml\Credential\Criteria\PrivateKeyCriteria;
 use LightSaml\Criteria\CriteriaSet;
 use LightSaml\Resolver\Credential\PrivateKeyResolver;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 class PrivateKeyResolverTest extends \PHPUnit_Framework_TestCase
 {
@@ -32,10 +33,10 @@ class PrivateKeyResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\XMLSecurityKey
+     * @return \PHPUnit_Framework_MockObject_MockObject|XMLSecurityKey
      */
     private function getXmlSecurityKeyMock()
     {
-        return $this->getMock(\XMLSecurityKey::class, [], [], '', false);
+        return $this->getMock(XMLSecurityKey::class, [], [], '', false);
     }
 }

--- a/tests/LightSaml/Tests/Resolver/Signature/OwnSignatureResolverTest.php
+++ b/tests/LightSaml/Tests/Resolver/Signature/OwnSignatureResolverTest.php
@@ -16,6 +16,7 @@ use LightSaml\Profile\Profiles;
 use LightSaml\Resolver\Credential\CredentialResolverQuery;
 use LightSaml\Resolver\Signature\OwnSignatureResolver;
 use LightSaml\Tests\TestHelper;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 class OwnSignatureResolverTest extends \PHPUnit_Framework_TestCase
 {
@@ -59,7 +60,7 @@ class OwnSignatureResolverTest extends \PHPUnit_Framework_TestCase
             ->willReturn($certificate = new X509Certificate());
         $credential1->expects($this->once())
             ->method('getPrivateKey')
-            ->willReturn($privateKey = new \XMLSecurityKey(\XMLSecurityKey::AES128_CBC));
+            ->willReturn($privateKey = new XMLSecurityKey(XMLSecurityKey::AES128_CBC));
 
         $signatureWriter = $signatureResolver->getSignature($context);
 


### PR DESCRIPTION
At the moment xmlseclibs v2.0 is the same as v1.3. The only changes are the new namespaces. This patch is just a preparation for any further updates.
