### PR TITLE
Run tests with PHP 7.0, HHVM and lowest requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,21 @@ language: php
 php:
     - 5.5
     - 5.6
+    - 7.0
+    - hhvm
 
-before_script:
+matrix:
+    include:
+        - php: 5.5
+          env: COMPOSER_FLAGS="--prefer-lowest"
+
+before_install:
     - composer self-update
     - composer --version
     - wget http://get.sensiolabs.org/php-cs-fixer.phar -O php-cs-fixer.phar
-    - COMPOSER_ROOT_VERSION=dev-master composer install
+
+install:
+    - COMPOSER_ROOT_VERSION=dev-master composer update --prefer-source $COMPOSER_FLAGS
 
 script:
     - php php-cs-fixer.phar fix --dry-run -v

--- a/tests/LightSaml/Tests/Command/BuildSPMetadataCommandTest.php
+++ b/tests/LightSaml/Tests/Command/BuildSPMetadataCommandTest.php
@@ -37,9 +37,9 @@ class BuildSPMetadataCommandTest extends \PHPUnit_Framework_TestCase
         // Equals to a user inputting "Test" and hitting ENTER
         // If you need to enter a confirmation, "yes\n" will work
 
-        $commandTester->execute(array('command' => $command->getName()));
+        $statusCode = $commandTester->execute(array('command' => $command->getName()));
 
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertEquals(0, $statusCode);
 
         fseek($file, 0);
         $xml = fread($file, 16000);


### PR DESCRIPTION
In order to make this library future-proof, we should test it with recent PHP engines. The same applies for all sub-projects (like `SpBundle`).
