### PR TITLE
Metadata loader #22

### DIFF
--- a/src/LightSaml/Model/Metadata/EntitiesDescriptor.php
+++ b/src/LightSaml/Model/Metadata/EntitiesDescriptor.php
@@ -14,11 +14,10 @@ namespace LightSaml\Model\Metadata;
 use LightSaml\Helper;
 use LightSaml\Model\Context\DeserializationContext;
 use LightSaml\Model\Context\SerializationContext;
-use LightSaml\Model\AbstractSamlModel;
 use LightSaml\Model\XmlDSig\Signature;
 use LightSaml\SamlConstants;
 
-class EntitiesDescriptor extends AbstractSamlModel
+class EntitiesDescriptor extends Metadata
 {
     /** @var  int */
     protected $validUntil;

--- a/src/LightSaml/Model/Metadata/EntityDescriptor.php
+++ b/src/LightSaml/Model/Metadata/EntityDescriptor.php
@@ -14,11 +14,10 @@ namespace LightSaml\Model\Metadata;
 use LightSaml\Helper;
 use LightSaml\Model\Context\DeserializationContext;
 use LightSaml\Model\Context\SerializationContext;
-use LightSaml\Model\AbstractSamlModel;
 use LightSaml\Model\XmlDSig\Signature;
 use LightSaml\SamlConstants;
 
-class EntityDescriptor extends AbstractSamlModel
+class EntityDescriptor extends Metadata
 {
     /** @var string */
     protected $entityID;

--- a/src/LightSaml/Model/Metadata/Metadata.php
+++ b/src/LightSaml/Model/Metadata/Metadata.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the LightSAML-Core package.
+ *
+ * (c) Milos Tomic <tmilos@lightsaml.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace LightSaml\Model\Metadata;
+
+use LightSaml\Error\LightSamlXmlException;
+use LightSaml\Model\AbstractSamlModel;
+use LightSaml\Model\Context\DeserializationContext;
+use LightSaml\Model\SamlElementInterface;
+use LightSaml\SamlConstants;
+
+abstract class Metadata extends AbstractSamlModel
+{
+    /**
+     * @param string $path
+     *
+     * @return EntitiesDescriptor|EntityDescriptor
+     */
+    public static function fromFile($path)
+    {
+        $deserializatonContext = new DeserializationContext();
+        $xml = file_get_contents($path);
+
+        return self::fromXML($xml, $deserializatonContext);
+    }
+
+    /**
+     * @param string                 $xml
+     * @param DeserializationContext $context
+     *
+     * @return EntityDescriptor|EntitiesDescriptor
+     *
+     * @throws \Exception
+     */
+    public static function fromXML($xml, DeserializationContext $context)
+    {
+        if (false == is_string($xml)) {
+            throw new \InvalidArgumentException('Expecting string');
+        }
+
+        $context->getDocument()->loadXML($xml);
+
+        $node = $context->getDocument()->firstChild;
+        while ($node && $node instanceof \DOMComment) {
+            $node = $node->nextSibling;
+        }
+        if (null === $node) {
+            throw new LightSamlXmlException('Empty XML');
+        }
+
+        if (SamlConstants::NS_METADATA !== $node->namespaceURI) {
+            throw new LightSamlXmlException(sprintf(
+                "Invalid namespace '%s' of the root XML element, expected '%s'",
+                $node->namespaceURI,
+                SamlConstants::NS_METADATA
+            ));
+        }
+
+        $map = array(
+            'EntityDescriptor' => '\LightSaml\Model\Metadata\EntityDescriptor',
+            'EntitiesDescriptor' => '\LightSaml\Model\Metadata\EntitiesDescriptor',
+        );
+
+        $rootElementName = $node->localName;
+
+        if (array_key_exists($rootElementName, $map)) {
+            if ($class = $map[$rootElementName]) {
+                /** @var SamlElementInterface $result */
+                $result = new $class();
+            } else {
+                throw new \LogicException('Deserialization of %s root element is not implemented');
+            }
+        } else {
+            throw new LightSamlXmlException(sprintf("Unknown SAML metadata '%s'", $rootElementName));
+        }
+
+        $result->deserialize($node, $context);
+
+        return $result;
+    }
+}

--- a/src/LightSaml/Model/Protocol/SamlMessage.php
+++ b/src/LightSaml/Model/Protocol/SamlMessage.php
@@ -71,9 +71,7 @@ abstract class SamlMessage extends AbstractSamlModel
             throw new LightSamlXmlException('Empty XML');
         }
 
-        if (SamlConstants::NS_PROTOCOL !== $context->getDocument()->namespaceURI &&
-            SamlConstants::NS_PROTOCOL !== $node->namespaceURI
-        ) {
+        if (SamlConstants::NS_PROTOCOL !== $node->namespaceURI) {
             throw new LightSamlXmlException(sprintf(
                 "Invalid namespace '%s' of the root XML element, expected '%s'",
                 $context->getDocument()->namespaceURI,
@@ -98,7 +96,7 @@ abstract class SamlMessage extends AbstractSamlModel
                 /** @var SamlElementInterface $result */
                 $result = new $class();
             } else {
-                throw new \Exception('Deserialization of %s root element is not implemented');
+                throw new \LogicException('Deserialization of %s root element is not implemented');
             }
         } else {
             throw new LightSamlXmlException(sprintf("Unknown SAML message '%s'", $rootElementName));

--- a/tests/LightSaml/Tests/Functional/Model/Metadata/EntitiesDescriptorFunctionalTest.php
+++ b/tests/LightSaml/Tests/Functional/Model/Metadata/EntitiesDescriptorFunctionalTest.php
@@ -216,5 +216,15 @@ class EntitiesDescriptorFunctionalTest extends \PHPUnit_Framework_TestCase
 
         $entitiesDescriptor = new EntitiesDescriptor();
         $entitiesDescriptor->deserialize($context->getDocument(), $context);
+        $this->assertCount(2935, $entitiesDescriptor->getAllEntityDescriptors());
+    }
+
+    /**
+     * @expectedException \LightSaml\Error\LightSamlXmlException
+     * @expectedExceptionMessage Expected 'EntitiesDescriptor' xml node and 'urn:oasis:names:tc:SAML:2.0:metadata' namespace but got node 'EntityDescriptor' and namespace 'urn:oasis:names:tc:SAML:2.0:metadata'
+     */
+    public function test_throws_on_entity_descriptor()
+    {
+        EntitiesDescriptor::load(__DIR__.'/../../../../../../resources/sample/EntityDescriptor/idp-ed.xml');
     }
 }

--- a/tests/LightSaml/Tests/Functional/Model/Metadata/EntityDescriptorFunctionalTest.php
+++ b/tests/LightSaml/Tests/Functional/Model/Metadata/EntityDescriptorFunctionalTest.php
@@ -115,11 +115,17 @@ class EntityDescriptorFunctionalTest extends \PHPUnit_Framework_TestCase
 
     public function test_deserialize_engine_surfconext_nl_authentication_idp_metadata()
     {
-        $context = new DeserializationContext();
-        $context->getDocument()->load(__DIR__.'/../../../../../../resources/sample/EntityDescriptor/engine.surfconext.nl_authentication_idp_metadata.xml');
+        $ed = EntityDescriptor::load(__DIR__.'/../../../../../../resources/sample/EntityDescriptor/engine.surfconext.nl_authentication_idp_metadata.xml');
+        $this->assertEquals('https://engine.surfconext.nl/authentication/idp/metadata', $ed->getEntityID());
+    }
 
-        $ed = new EntityDescriptor();
-        $ed->deserialize($context->getDocument(), $context);
+    /**
+     * @expectedException \LightSaml\Error\LightSamlXmlException
+     * @expectedExceptionMessage Expected 'EntityDescriptor' xml node and 'urn:oasis:names:tc:SAML:2.0:metadata' namespace but got node 'EntitiesDescriptor' and namespace 'urn:oasis:names:tc:SAML:2.0:metadata'
+     */
+    public function test_throws_on_entities_descriptor_document()
+    {
+        EntityDescriptor::load(__DIR__.'/../../../../../../resources/sample/EntitiesDescriptor/testshib-providers.xml');
     }
 
     private function checkKD(SSODescriptor $descriptor, $use, $certificate)

--- a/tests/LightSaml/Tests/Functional/Model/Metadata/MetadataTest.php
+++ b/tests/LightSaml/Tests/Functional/Model/Metadata/MetadataTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LightSaml\Tests\Functional\Model\Metadata;
+
+use LightSaml\Model\Metadata\EntitiesDescriptor;
+use LightSaml\Model\Metadata\EntityDescriptor;
+use LightSaml\Model\Metadata\Metadata;
+
+class MetadataTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_loads_from_entity_descriptor()
+    {
+        $ed = Metadata::fromFile(__DIR__.'/../../../../../../resources/sample/EntityDescriptor/idp2-ed.xml');
+        $this->assertInstanceOf(EntityDescriptor::class, $ed);
+        $this->assertEquals('https://B1.bead.loc/adfs/services/trust', $ed->getEntityID());
+    }
+
+    public function test_loads_from_entities_descriptor()
+    {
+        $eds = Metadata::fromFile(__DIR__.'/../../../../../../resources/sample/EntitiesDescriptor/testshib-providers.xml');
+        $this->assertInstanceOf(EntitiesDescriptor::class, $eds);
+        $this->assertCount(2, $eds->getAllEntityDescriptors());
+    }
+}


### PR DESCRIPTION
Convenient `MetadataLoader` class for metadata xml documents, like `SamlMessage` is for protocol documents
