### PR TITLE
Fix Status constructor

### DIFF
--- a/src/LightSaml/Model/Protocol/Status.php
+++ b/src/LightSaml/Model/Protocol/Status.php
@@ -31,7 +31,7 @@ class Status extends AbstractSamlModel
     public function __construct(StatusCode $statusCode = null, $message = null)
     {
         $this->statusCode = $statusCode;
-        $this->message = $message;
+        $this->statusMessage = $message;
     }
 
     /**

--- a/tests/LightSaml/Tests/Model/Protocol/StatusTest.php
+++ b/tests/LightSaml/Tests/Model/Protocol/StatusTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LightSaml\Tests\Model\Protocol;
+
+use LightSaml\Model\Protocol\Status;
+use LightSaml\SamlConstants;
+
+class ResponseTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_status_set_message_constructor()
+    {
+        $message = "Test message";
+        $status = new Status(new StatusCode(SamlConstants::STATUS_SUCCESS), $message);
+        $this->assertEquals($status->getStatusMessage(), $message);
+    }
+    
+    public function test_status_set_message_setter()
+    {
+        $message = "Test message";
+        $status = new Status(new StatusCode(SamlConstants::STATUS_SUCCESS));
+        $status->setStatusMessage($message);
+        $this->assertEquals($status->getStatusMessage(), $message);
+    }
+}

--- a/tests/LightSaml/Tests/Model/Protocol/StatusTest.php
+++ b/tests/LightSaml/Tests/Model/Protocol/StatusTest.php
@@ -3,6 +3,7 @@
 namespace LightSaml\Tests\Model\Protocol;
 
 use LightSaml\Model\Protocol\Status;
+use LightSaml\Model\Protocol\StatusCode;
 use LightSaml\SamlConstants;
 
 class StatusTest extends \PHPUnit_Framework_TestCase

--- a/tests/LightSaml/Tests/Model/Protocol/StatusTest.php
+++ b/tests/LightSaml/Tests/Model/Protocol/StatusTest.php
@@ -5,7 +5,7 @@ namespace LightSaml\Tests\Model\Protocol;
 use LightSaml\Model\Protocol\Status;
 use LightSaml\SamlConstants;
 
-class ResponseTest extends \PHPUnit_Framework_TestCase
+class StatusTest extends \PHPUnit_Framework_TestCase
 {
     public function test_status_set_message_constructor()
     {


### PR DESCRIPTION
The constructor mistakenly sets `message` instead of `statusMessage`, causing the XML to not include `StatusMessage` on serialization if the constructor is used to initialize the message.