### PR TITLE
Fix potential error in X509Certificate

### DIFF
--- a/src/LightSaml/Credential/X509Certificate.php
+++ b/src/LightSaml/Credential/X509Certificate.php
@@ -124,7 +124,7 @@ class X509Certificate
         $res = openssl_x509_read($this->toPem());
         $this->info = openssl_x509_parse($res);
         $this->signatureAlgorithm = null;
-        $signatureType = isset($info['signatureTypeSN']) ? $info['signatureTypeSN'] : '';
+        $signatureType = isset($this->info['signatureTypeSN']) ? $this->info['signatureTypeSN'] : '';
         if ($signatureType && isset(self::$typeMap[$signatureType])) {
             $this->signatureAlgorithm = self::$typeMap[$signatureType];
         } else {


### PR DESCRIPTION
I'm not entirely sure how this will behave with the fix (haven't tested it), but I was reading through the code and I noticed this. `$info` isn't defined anywhere, I'm pretty sure it was meant to be `$this->info` but because it's wrapped by an `isset()`, the code never gets run and just spits out `''` every time.