### PR TITLE
Removing use of Class::class for PHP 5.6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,22 @@
 {
-    "name": "lightsaml/lightsaml",
+    "name": "kidatsy/lightsaml-lightsaml",
     "license": "MIT",
     "type": "library",
-    "description": "Light SAML 2.0 PHP library",
+    "description": "Clone of Light SAML 2.0 PHP library, enabling PHP 5.6",
     "keywords": ["SAML 2.0", "PHP", "library", "lightSAML", "Single SignOn", "Single Logout"],
     "homepage": "https://www.lightsaml.com/",
     "authors": [
         {
             "name": "Milos Tomic",
             "email": "tmilos@gmail.com",
-            "homepage": "https://github.com/tmilos/",
+            "homepage": "http://github.com/tmilos",
             "role": "Developer"
+        },
+        {
+            "name": "Toshiro Kida",
+            "email": "toshiro.kida@gmail.com",
+            "homepage": "https://github.com/kidatsy",
+            "role": "Cloner"
         }
     ],
     "support": {
@@ -39,8 +45,8 @@
         "satooshi/php-coveralls": "~0.6"
     },
     "suggest": {
-        "lightsaml/symfony-bridge": "Symfony 2 build container bridge",
-        "lightsaml/sp-bundle": "Symfony 2 SP security bundle"
+        "kidatsy/lightsaml-symfony-bridge": "Symfony 2 build container bridge",
+        "kidatsy/lightsaml-sp-bundle": "Symfony 2 SP security bundle"
     },
     "config": {
         "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,16 @@
 {
-    "name": "kidatsy/lightsaml-lightsaml",
+    "name": "lightsaml/lightsaml",
     "license": "MIT",
     "type": "library",
-    "description": "Clone of Light SAML 2.0 PHP library, enabling PHP 5.6",
+    "description": "Light SAML 2.0 PHP library",
     "keywords": ["SAML 2.0", "PHP", "library", "lightSAML", "Single SignOn", "Single Logout"],
     "homepage": "https://www.lightsaml.com/",
     "authors": [
         {
             "name": "Milos Tomic",
             "email": "tmilos@gmail.com",
-            "homepage": "http://github.com/tmilos",
+            "homepage": "https://github.com/tmilos/",
             "role": "Developer"
-        },
-        {
-            "name": "Toshiro Kida",
-            "email": "toshiro.kida@gmail.com",
-            "homepage": "https://github.com/kidatsy",
-            "role": "Cloner"
         }
     ],
     "support": {
@@ -45,8 +39,8 @@
         "satooshi/php-coveralls": "~0.6"
     },
     "suggest": {
-        "kidatsy/lightsaml-symfony-bridge": "Symfony 2 build container bridge",
-        "kidatsy/lightsaml-sp-bundle": "Symfony 2 SP security bundle"
+        "lightsaml/symfony-bridge": "Symfony 2 build container bridge",
+        "lightsaml/sp-bundle": "Symfony 2 SP security bundle"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/LightSaml/Action/Assertion/Inbound/InResponseToValidatorAction.php
+++ b/src/LightSaml/Action/Assertion/Inbound/InResponseToValidatorAction.php
@@ -55,7 +55,7 @@ class InResponseToValidatorAction extends AbstractAssertionAction
                 );
 
                 /** @var RequestStateContext $requestStateContext */
-                $requestStateContext = $context->getSubContext(ProfileContexts::REQUEST_STATE, RequestStateContext::class);
+                $requestStateContext = $context->getSubContext(ProfileContexts::REQUEST_STATE, 'LightSaml\Context\Profile\RequestStateContext');
                 $requestStateContext->setRequestState($requestState);
             }
         }

--- a/src/LightSaml/Action/Assertion/Inbound/RecipientValidatorAction.php
+++ b/src/LightSaml/Action/Assertion/Inbound/RecipientValidatorAction.php
@@ -77,8 +77,8 @@ class RecipientValidatorAction extends AbstractAssertionAction
         }
 
         $criteriaSet = new CriteriaSet([
-            new DescriptorTypeCriteria(SpSsoDescriptor::class),
-            new ServiceTypeCriteria(AssertionConsumerService::class),
+            new DescriptorTypeCriteria('LightSaml\Model\Metadata\SpSsoDescriptor'),
+            new ServiceTypeCriteria('LightSaml\Model\Metadata\AssertionConsumerService'),
             new LocationCriteria($recipient),
         ]);
         $ownEntityDescriptor = $context->getProfileContext()->getOwnEntityDescriptor();

--- a/src/LightSaml/Action/CatchableErrorAction.php
+++ b/src/LightSaml/Action/CatchableErrorAction.php
@@ -44,7 +44,7 @@ class CatchableErrorAction implements ActionInterface
             $this->mainAction->execute($context);
         } catch (\Exception $ex) {
             /** @var ExceptionContext $exceptionContext */
-            $exceptionContext = $context->getSubContext(ProfileContexts::EXCEPTION, ExceptionContext::class);
+            $exceptionContext = $context->getSubContext(ProfileContexts::EXCEPTION, 'LightSaml\Context\Profile\ExceptionContext');
             $exceptionContext->addException($ex);
 
             $this->errorAction->execute($context);

--- a/src/LightSaml/Action/CompositeAction.php
+++ b/src/LightSaml/Action/CompositeAction.php
@@ -90,7 +90,7 @@ class CompositeAction implements ActionInterface, DebugPrintTreeActionInterface,
         }
 
         $result = array(
-            static::class => $arr,
+            get_class(self) => $arr,
         );
 
         return $result;

--- a/src/LightSaml/Action/Profile/Entity/SerializeOwnEntityAction.php
+++ b/src/LightSaml/Action/Profile/Entity/SerializeOwnEntityAction.php
@@ -30,7 +30,7 @@ class SerializeOwnEntityAction extends AbstractProfileAction
         $ownEntityDescriptor = $context->getOwnEntityDescriptor();
 
         /** @var SerializationContext $serializationContext */
-        $serializationContext = $context->getSubContext(ProfileContexts::SERIALIZATION, SerializationContext::class);
+        $serializationContext = $context->getSubContext(ProfileContexts::SERIALIZATION, 'LightSaml\Model\Context\SerializationContext');
         $serializationContext->getDocument()->formatOutput = true;
 
         $ownEntityDescriptor->serialize($serializationContext->getDocument(), $serializationContext);

--- a/src/LightSaml/Action/Profile/Inbound/Message/AbstractDestinationValidatorAction.php
+++ b/src/LightSaml/Action/Profile/Inbound/Message/AbstractDestinationValidatorAction.php
@@ -77,8 +77,8 @@ abstract class AbstractDestinationValidatorAction extends AbstractProfileAction
         $criteriaSet = new CriteriaSet([
             new DescriptorTypeCriteria(
                 $context->getOwnRole() === ProfileContext::ROLE_IDP
-                ? IdpSsoDescriptor::class
-                : SpSsoDescriptor::class
+                ? 'LightSaml\Model\Metadata\IdpSsoDescriptor'
+                : 'LightSaml\Model\Metadata\SpSsoDescriptor'
             ),
             new LocationCriteria($location),
         ]);

--- a/src/LightSaml/Action/Profile/Inbound/Message/DestinationValidatorAuthnRequestAction.php
+++ b/src/LightSaml/Action/Profile/Inbound/Message/DestinationValidatorAuthnRequestAction.php
@@ -28,7 +28,7 @@ class DestinationValidatorAuthnRequestAction extends AbstractDestinationValidato
     {
         $result = parent::getCriteriaSet($context, $location);
 
-        $result->add(new ServiceTypeCriteria(SingleSignOnService::class));
+        $result->add(new ServiceTypeCriteria('LightSaml\Model\Metadata\SingleSignOnService'));
 
         return $result;
     }

--- a/src/LightSaml/Action/Profile/Inbound/Message/DestinationValidatorResponseAction.php
+++ b/src/LightSaml/Action/Profile/Inbound/Message/DestinationValidatorResponseAction.php
@@ -28,7 +28,7 @@ class DestinationValidatorResponseAction extends AbstractDestinationValidatorAct
     {
         $result = parent::getCriteriaSet($context, $location);
 
-        $result->add(new ServiceTypeCriteria(AssertionConsumerService::class));
+        $result->add(new ServiceTypeCriteria('LightSaml\Model\Metadata\AssertionConsumerService'));
 
         return $result;
     }

--- a/src/LightSaml/Action/Profile/Inbound/Response/AssertionAction.php
+++ b/src/LightSaml/Action/Profile/Inbound/Response/AssertionAction.php
@@ -45,7 +45,7 @@ class AssertionAction extends AbstractProfileAction implements DebugPrintTreeAct
         foreach ($response->getAllAssertions() as $index => $assertion) {
             $name = sprintf('assertion_%s', $index);
             /** @var AssertionContext $assertionContext */
-            $assertionContext = $context->getSubContext($name, AssertionContext::class);
+            $assertionContext = $context->getSubContext($name, 'LightSaml\Context\Profile\AssertionContext');
             $assertionContext
                 ->setAssertion($assertion)
                 ->setId($name)
@@ -70,7 +70,7 @@ class AssertionAction extends AbstractProfileAction implements DebugPrintTreeAct
         }
 
         $result = array(
-            static::class => $arr,
+            get_class(self) => $arr,
         );
 
         return $result;

--- a/src/LightSaml/Action/Profile/Inbound/Response/DecryptAssertionsAction.php
+++ b/src/LightSaml/Action/Profile/Inbound/Response/DecryptAssertionsAction.php
@@ -90,7 +90,7 @@ class DecryptAssertionsAction extends AbstractProfileAction
             if ($encryptedAssertion instanceof EncryptedAssertionReader) {
                 $name = sprintf('assertion_encrypted_%s', $index);
                 /** @var DeserializationContext $deserializationContext */
-                $deserializationContext = $context->getInboundContext()->getSubContext($name, DeserializationContext::class);
+                $deserializationContext = $context->getInboundContext()->getSubContext($name, 'LightSaml\Model\Context\DeserializationContext');
                 $assertion = $encryptedAssertion->decryptMultiAssertion($privateKeys, $deserializationContext);
                 $response->addAssertion($assertion);
 

--- a/src/LightSaml/Action/Profile/Inbound/StatusResponse/InResponseToValidatorAction.php
+++ b/src/LightSaml/Action/Profile/Inbound/StatusResponse/InResponseToValidatorAction.php
@@ -65,7 +65,7 @@ class InResponseToValidatorAction extends AbstractProfileAction
             }
 
             /** @var RequestStateContext $requestStateContext */
-            $requestStateContext = $context->getInboundContext()->getSubContext(ProfileContexts::REQUEST_STATE, RequestStateContext::class);
+            $requestStateContext = $context->getInboundContext()->getSubContext(ProfileContexts::REQUEST_STATE, 'LightSaml\Context\Profile\RequestStateContext');
             $requestStateContext->setRequestState($requestState);
         }
     }

--- a/src/LightSaml/Action/Profile/Outbound/AuthnRequest/ACSUrlAction.php
+++ b/src/LightSaml/Action/Profile/Outbound/AuthnRequest/ACSUrlAction.php
@@ -44,8 +44,8 @@ class ACSUrlAction extends AbstractProfileAction
         $ownEntityDescriptor = $context->getOwnEntityDescriptor();
 
         $criteriaSet = new CriteriaSet([
-            new DescriptorTypeCriteria(SpSsoDescriptor::class),
-            new ServiceTypeCriteria(AssertionConsumerService::class),
+            new DescriptorTypeCriteria('LightSaml\Model\Metadata\SpSsoDescriptor'),
+            new ServiceTypeCriteria('LightSaml\Model\Metadata\AssertionConsumerService'),
             new BindingCriteria([SamlConstants::BINDING_SAML2_HTTP_POST]),
         ]);
 

--- a/src/LightSaml/Action/Profile/Outbound/Message/ResolveEndpointBaseAction.php
+++ b/src/LightSaml/Action/Profile/Outbound/Message/ResolveEndpointBaseAction.php
@@ -156,8 +156,8 @@ abstract class ResolveEndpointBaseAction extends AbstractProfileAction
     protected function getDescriptorType(ProfileContext $context)
     {
         return $context->getOwnRole() == ProfileContext::ROLE_IDP
-            ? SpSsoDescriptor::class
-            : IdpSsoDescriptor::class;
+            ? 'LightSaml\Model\Metadata\SpSsoDescriptor'
+            : 'LightSaml\Model\Metadata\IdpSsoDescriptor';
     }
 
     /**

--- a/src/LightSaml/Action/Profile/Outbound/Message/ResolveEndpointIdpSsoAction.php
+++ b/src/LightSaml/Action/Profile/Outbound/Message/ResolveEndpointIdpSsoAction.php
@@ -18,6 +18,6 @@ class ResolveEndpointIdpSsoAction extends ResolveEndpointBaseAction
 {
     protected function getServiceType(ProfileContext $context)
     {
-        return SingleSignOnService::class;
+        return 'LightSaml\Model\Metadata\SingleSignOnService';
     }
 }

--- a/src/LightSaml/Action/Profile/Outbound/Message/ResolveEndpointSloAction.php
+++ b/src/LightSaml/Action/Profile/Outbound/Message/ResolveEndpointSloAction.php
@@ -21,7 +21,7 @@ class ResolveEndpointSloAction extends ResolveEndpointBaseAction
 {
     protected function getServiceType(ProfileContext $context)
     {
-        return SingleLogoutService::class;
+        return'LightSaml\Model\Metadata\SingleLogoutService';
     }
 
     protected function getDescriptorType(ProfileContext $context)
@@ -30,9 +30,9 @@ class ResolveEndpointSloAction extends ResolveEndpointBaseAction
         $ownEntityId = $context->getOwnEntityDescriptor()->getEntityID();
 
         if ($ssoSessionState->getIdpEntityId() == $ownEntityId) {
-            return SpSsoDescriptor::class;
+            return 'LightSaml\Model\Metadata\SpSsoDescriptor';
         } elseif ($ssoSessionState->getSpEntityId() == $ownEntityId) {
-            return IdpSsoDescriptor::class;
+            return 'LightSaml\Model\Metadata\IdpSsoDescriptor';
         } else {
             throw new LightSamlContextException($context, 'Unable to resolve logout target descriptor type');
         }

--- a/src/LightSaml/Action/Profile/Outbound/Message/ResolveEndpointSpAcsAction.php
+++ b/src/LightSaml/Action/Profile/Outbound/Message/ResolveEndpointSpAcsAction.php
@@ -18,6 +18,6 @@ class ResolveEndpointSpAcsAction extends ResolveEndpointBaseAction
 {
     protected function getServiceType(ProfileContext $context)
     {
-        return AssertionConsumerService::class;
+        return 'LightSaml\Model\Metadata\AssertionConsumerService';
     }
 }

--- a/src/LightSaml/Context/AbstractContext.php
+++ b/src/LightSaml/Context/AbstractContext.php
@@ -169,7 +169,7 @@ abstract class AbstractContext implements ContextInterface
     public function debugPrintTree($ownName = 'root')
     {
         $result = array(
-            $ownName => static::class,
+            $ownName => get_class(self),
         );
 
         if ($this->subContexts) {

--- a/src/LightSaml/Context/Profile/MessageContext.php
+++ b/src/LightSaml/Context/Profile/MessageContext.php
@@ -120,7 +120,7 @@ class MessageContext extends AbstractProfileContext
      */
     public function getSerializationContext()
     {
-        return $this->getSubContext(ProfileContexts::SERIALIZATION, SerializationContext::class);
+        return $this->getSubContext(ProfileContexts::SERIALIZATION, 'LightSaml\Model\Context\SerializationContext');
     }
 
     /**
@@ -128,6 +128,6 @@ class MessageContext extends AbstractProfileContext
      */
     public function getDeserializationContext()
     {
-        return $this->getSubContext(ProfileContexts::DESERIALIZATION, DeserializationContext::class);
+        return $this->getSubContext(ProfileContexts::DESERIALIZATION, 'LightSaml\Model\Context\DeserializationContext');
     }
 }

--- a/src/LightSaml/Context/Profile/ProfileContext.php
+++ b/src/LightSaml/Context/Profile/ProfileContext.php
@@ -79,7 +79,7 @@ class ProfileContext extends AbstractProfileContext
      */
     public function getInboundContext()
     {
-        return $this->getSubContext(ProfileContexts::INBOUND_MESSAGE, MessageContext::class);
+        return $this->getSubContext(ProfileContexts::INBOUND_MESSAGE, 'LightSaml\Context\Profile\MessageContext');
     }
 
     /**
@@ -87,7 +87,7 @@ class ProfileContext extends AbstractProfileContext
      */
     public function getOutboundContext()
     {
-        return $this->getSubContext(ProfileContexts::OUTBOUND_MESSAGE, MessageContext::class);
+        return $this->getSubContext(ProfileContexts::OUTBOUND_MESSAGE, 'LightSaml\Context\Profile\MessageContext');
     }
 
     /**
@@ -95,7 +95,7 @@ class ProfileContext extends AbstractProfileContext
      */
     public function getHttpRequestContext()
     {
-        return $this->getSubContext(ProfileContexts::HTTP_REQUEST, HttpRequestContext::class);
+        return $this->getSubContext(ProfileContexts::HTTP_REQUEST, 'LightSaml\Context\Profile\HttpRequestContext');
     }
 
     /**
@@ -103,7 +103,7 @@ class ProfileContext extends AbstractProfileContext
      */
     public function getHttpResponseContext()
     {
-        return $this->getSubContext(ProfileContexts::HTTP_RESPONSE, HttpResponseContext::class);
+        return $this->getSubContext(ProfileContexts::HTTP_RESPONSE, 'LightSaml\Context\Profile\HttpResponseContext');
     }
 
     /**
@@ -111,7 +111,7 @@ class ProfileContext extends AbstractProfileContext
      */
     public function getOwnEntityContext()
     {
-        return $this->getSubContext(ProfileContexts::OWN_ENTITY, EntityContext::class);
+        return $this->getSubContext(ProfileContexts::OWN_ENTITY, 'LightSaml\Context\Profile\EntityContext');
     }
 
     /**
@@ -119,7 +119,7 @@ class ProfileContext extends AbstractProfileContext
      */
     public function getPartyEntityContext()
     {
-        return $this->getSubContext(ProfileContexts::PARTY_ENTITY, EntityContext::class);
+        return $this->getSubContext(ProfileContexts::PARTY_ENTITY, 'LightSaml\Context\Profile\EntityContext');
     }
 
     /**
@@ -127,7 +127,7 @@ class ProfileContext extends AbstractProfileContext
      */
     public function getEndpointContext()
     {
-        return $this->getSubContext(ProfileContexts::ENDPOINT, EndpointContext::class);
+        return $this->getSubContext(ProfileContexts::ENDPOINT, 'LightSaml\Context\Profile\EndpointContext');
     }
 
     /**
@@ -135,7 +135,7 @@ class ProfileContext extends AbstractProfileContext
      */
     public function getLogoutContext()
     {
-        return $this->getSubContext(ProfileContexts::LOGOUT, LogoutContext::class);
+        return $this->getSubContext(ProfileContexts::LOGOUT, 'LightSaml\Context\Profile\LogoutContext');
     }
 
     /**

--- a/src/LightSaml/Resolver/Credential/AlgorithmFilterResolver.php
+++ b/src/LightSaml/Resolver/Credential/AlgorithmFilterResolver.php
@@ -25,12 +25,12 @@ class AlgorithmFilterResolver extends AbstractQueryableResolver
      */
     public function resolve(CriteriaSet $criteriaSet, array $arrCredentials = array())
     {
-        if (false == $criteriaSet->has(AlgorithmCriteria::class)) {
+        if (false == $criteriaSet->has('LightSaml\Credential\Criteria\AlgorithmCriteria')) {
             return $arrCredentials;
         }
 
         $result = array();
-        foreach ($criteriaSet->get(AlgorithmCriteria::class) as $criteria) {
+        foreach ($criteriaSet->get('LightSaml\Credential\Criteria\AlgorithmCriteria') as $criteria) {
             /* @var AlgorithmCriteria $criteria */
             foreach ($arrCredentials as $credential) {
                 if (($credential->getPrivateKey() && $credential->getPrivateKey()->getAlgorith() == $criteria->getAlgorithm()) ||

--- a/src/LightSaml/Resolver/Credential/CredentialNameFilterResolver.php
+++ b/src/LightSaml/Resolver/Credential/CredentialNameFilterResolver.php
@@ -25,12 +25,12 @@ class CredentialNameFilterResolver extends AbstractQueryableResolver
      */
     public function resolve(CriteriaSet $criteriaSet, array $arrCredentials = array())
     {
-        if (false == $criteriaSet->has(CredentialNameCriteria::class)) {
+        if (false == $criteriaSet->has('LightSaml\Credential\Criteria\CredentialNameCriteria')) {
             return $arrCredentials;
         }
 
         $result = array();
-        foreach ($criteriaSet->get(CredentialNameCriteria::class) as $criteria) {
+        foreach ($criteriaSet->get('LightSaml\Credential\Criteria\CredentialNameCriteria') as $criteria) {
             /* @var CredentialNameCriteria $criteria */
             foreach ($arrCredentials as $credential) {
                 $arrCredentialNames = $credential->getKeyNames();

--- a/src/LightSaml/Resolver/Credential/EntityIdResolver.php
+++ b/src/LightSaml/Resolver/Credential/EntityIdResolver.php
@@ -38,7 +38,7 @@ class EntityIdResolver extends AbstractQueryableResolver
     public function resolve(CriteriaSet $criteriaSet, array $arrCredentials = array())
     {
         $result = array();
-        foreach ($criteriaSet->get(EntityIdCriteria::class) as $criteria) {
+        foreach ($criteriaSet->get('LightSaml\Credential\Criteria\EntityIdCriteria') as $criteria) {
             /* @var EntityIdCriteria $criteria */
             $result = array_merge($result, $this->credentialStore->getByEntityId($criteria->getEntityId()));
         }

--- a/src/LightSaml/Resolver/Credential/MetadataFilterResolver.php
+++ b/src/LightSaml/Resolver/Credential/MetadataFilterResolver.php
@@ -28,16 +28,16 @@ class MetadataFilterResolver extends AbstractQueryableResolver
      */
     public function resolve(CriteriaSet $criteriaSet, array $arrCredentials = array())
     {
-        if (false == $criteriaSet->has(MetadataCriteria::class)) {
+        if (false == $criteriaSet->has('LightSaml\Credential\Criteria\MetadataCriteria')) {
             return $arrCredentials;
         }
 
         $result = array();
-        foreach ($criteriaSet->get(MetadataCriteria::class) as $criteria) {
+        foreach ($criteriaSet->get('LightSaml\Credential\Criteria\MetadataCriteria') as $criteria) {
             /* @var MetadataCriteria $criteria */
             foreach ($arrCredentials as $credential) {
                 /** @var MetadataCredentialContext $metadataContext */
-                $metadataContext = $credential->getCredentialContext()->get(MetadataCredentialContext::class);
+                $metadataContext = $credential->getCredentialContext()->get('LightSaml\Credential\Context\MetadataCredentialContext');
                 if (false == $metadataContext ||
                     $criteria->getMetadataType() == MetadataCriteria::TYPE_IDP && $metadataContext->getRoleDescriptor() instanceof IdpSsoDescriptor ||
                     $criteria->getMetadataType() == MetadataCriteria::TYPE_SP && $metadataContext->getRoleDescriptor() instanceof SpSsoDescriptor

--- a/src/LightSaml/Resolver/Credential/PrivateKeyResolver.php
+++ b/src/LightSaml/Resolver/Credential/PrivateKeyResolver.php
@@ -25,7 +25,7 @@ class PrivateKeyResolver extends AbstractQueryableResolver
      */
     public function resolve(CriteriaSet $criteriaSet, array $arrCredentials = array())
     {
-        if (false == $criteriaSet->has(PrivateKeyCriteria::class)) {
+        if (false == $criteriaSet->has('LightSaml\Credential\Criteria\PrivateKeyCriteria')) {
             return $arrCredentials;
         }
 

--- a/src/LightSaml/Resolver/Credential/PublicKeyThumbprintResolver.php
+++ b/src/LightSaml/Resolver/Credential/PublicKeyThumbprintResolver.php
@@ -25,13 +25,13 @@ class PublicKeyThumbprintResolver extends AbstractQueryableResolver
      */
     public function resolve(CriteriaSet $criteriaSet, array $arrCredentials = array())
     {
-        if (false == $criteriaSet->has(PublicKeyThumbprintCriteria::class)) {
+        if (false == $criteriaSet->has('LightSaml\Credential\Criteria\PublicKeyThumbprintCriteria')) {
             return $arrCredentials;
         }
 
         $result = array();
         /** @var PublicKeyThumbprintCriteria $criteria */
-        foreach ($criteriaSet->get(PublicKeyThumbprintCriteria::class) as $criteria) {
+        foreach ($criteriaSet->get('LightSaml\Credential\Criteria\PublicKeyThumbprintCriteria') as $criteria) {
             foreach ($arrCredentials as $credential) {
                 if ($credential->getPublicKey() && $credential->getPublicKey()->getX509Thumbprint() == $criteria->getThumbprint()) {
                     $result[] = $credential;

--- a/src/LightSaml/Resolver/Credential/UsageFilterResolver.php
+++ b/src/LightSaml/Resolver/Credential/UsageFilterResolver.php
@@ -25,12 +25,12 @@ class UsageFilterResolver extends AbstractQueryableResolver
      */
     public function resolve(CriteriaSet $criteriaSet, array $arrCredentials = array())
     {
-        if (false == $criteriaSet->has(UsageCriteria::class)) {
+        if (false == $criteriaSet->has('LightSaml\Credential\Criteria\UsageCriteria')) {
             return $arrCredentials;
         }
 
         $result = array();
-        foreach ($criteriaSet->get(UsageCriteria::class) as $criteria) {
+        foreach ($criteriaSet->get('LightSaml\Credential\Criteria\UsageCriteria') as $criteria) {
             /* @var UsageCriteria $criteria */
             foreach ($arrCredentials as $credential) {
                 if (false == $credential->getUsageType() || $criteria->getUsage() == $credential->getUsageType()) {

--- a/src/LightSaml/Resolver/Credential/X509CredentialResolver.php
+++ b/src/LightSaml/Resolver/Credential/X509CredentialResolver.php
@@ -26,7 +26,7 @@ class X509CredentialResolver extends AbstractQueryableResolver
      */
     public function resolve(CriteriaSet $criteriaSet, array $arrCredentials = array())
     {
-        if (false == $criteriaSet->has(X509CredentialCriteria::class)) {
+        if (false == $criteriaSet->has('LightSaml\Credential\Criteria\X509CredentialCriteria')) {
             return $arrCredentials;
         }
 

--- a/src/LightSaml/Resolver/Endpoint/BindingEndpointResolver.php
+++ b/src/LightSaml/Resolver/Endpoint/BindingEndpointResolver.php
@@ -25,13 +25,13 @@ class BindingEndpointResolver implements EndpointResolverInterface
      */
     public function resolve(CriteriaSet $criteriaSet, array $candidates)
     {
-        if (false === $criteriaSet->has(BindingCriteria::class)) {
+        if (false === $criteriaSet->has('LightSaml\Resolver\Endpoint\Criteria\BindingCriteria')) {
             return $candidates;
         }
 
         $arrOrdered = array();
         /** @var BindingCriteria $bindingCriteria */
-        foreach ($criteriaSet->get(BindingCriteria::class) as $bindingCriteria) {
+        foreach ($criteriaSet->get('LightSaml\Resolver\Endpoint\Criteria\BindingCriteria') as $bindingCriteria) {
             foreach ($candidates as $endpointReference) {
                 $preference = $bindingCriteria->getPreference($endpointReference->getEndpoint()->getBinding());
                 if (null !== $preference) {

--- a/src/LightSaml/Resolver/Endpoint/DescriptorTypeEndpointResolver.php
+++ b/src/LightSaml/Resolver/Endpoint/DescriptorTypeEndpointResolver.php
@@ -30,13 +30,13 @@ class DescriptorTypeEndpointResolver implements EndpointResolverInterface
      */
     public function resolve(CriteriaSet $criteriaSet, array $candidates)
     {
-        if (false === $criteriaSet->has(DescriptorTypeCriteria::class)) {
+        if (false === $criteriaSet->has('LightSaml\Resolver\Endpoint\Criteria\DescriptorTypeCriteria')) {
             return $candidates;
         }
 
         $result = array();
         /** @var DescriptorTypeCriteria $descriptorTypeCriteria */
-        foreach ($criteriaSet->get(DescriptorTypeCriteria::class) as $descriptorTypeCriteria) {
+        foreach ($criteriaSet->get('LightSaml\Resolver\Endpoint\Criteria\DescriptorTypeCriteria') as $descriptorTypeCriteria) {
             foreach ($candidates as $endpointReference) {
                 $type = $descriptorTypeCriteria->getDescriptorType();
                 if ($endpointReference->getDescriptor() instanceof $type) {

--- a/src/LightSaml/Resolver/Endpoint/IndexEndpointResolver.php
+++ b/src/LightSaml/Resolver/Endpoint/IndexEndpointResolver.php
@@ -26,13 +26,13 @@ class IndexEndpointResolver implements EndpointResolverInterface
      */
     public function resolve(CriteriaSet $criteriaSet, array $candidates)
     {
-        if (false === $criteriaSet->has(IndexCriteria::class)) {
+        if (false === $criteriaSet->has('LightSaml\Resolver\Endpoint\Criteria\IndexCriteria')) {
             return $candidates;
         }
 
         $result = array();
         /** @var IndexCriteria $indexCriteria */
-        foreach ($criteriaSet->get(IndexCriteria::class) as $indexCriteria) {
+        foreach ($criteriaSet->get('LightSaml\Resolver\Endpoint\Criteria\IndexCriteria') as $indexCriteria) {
             foreach ($candidates as $endpointReference) {
                 $endpoint = $endpointReference->getEndpoint();
                 if ($endpoint instanceof IndexedEndpoint) {

--- a/src/LightSaml/Resolver/Endpoint/LocationEndpointResolver.php
+++ b/src/LightSaml/Resolver/Endpoint/LocationEndpointResolver.php
@@ -25,13 +25,13 @@ class LocationEndpointResolver implements EndpointResolverInterface
      */
     public function resolve(CriteriaSet $criteriaSet, array $candidates)
     {
-        if (false === $criteriaSet->has(LocationCriteria::class)) {
+        if (false === $criteriaSet->has('LightSaml\Resolver\Endpoint\Criteria\LocationCriteria')) {
             return $candidates;
         }
 
         $result = array();
         /** @var LocationCriteria $locationCriteria */
-        foreach ($criteriaSet->get(LocationCriteria::class) as $locationCriteria) {
+        foreach ($criteriaSet->get('LightSaml\Resolver\Endpoint\Criteria\LocationCriteria') as $locationCriteria) {
             foreach ($candidates as $endpointReference) {
                 if ($endpointReference->getEndpoint()->getLocation() == $locationCriteria->getLocation()) {
                     $result[] = $endpointReference;

--- a/src/LightSaml/Resolver/Endpoint/ServiceTypeEndpointResolver.php
+++ b/src/LightSaml/Resolver/Endpoint/ServiceTypeEndpointResolver.php
@@ -30,13 +30,13 @@ class ServiceTypeEndpointResolver implements EndpointResolverInterface
      */
     public function resolve(CriteriaSet $criteriaSet, array $candidates)
     {
-        if (false === $criteriaSet->has(ServiceTypeCriteria::class)) {
+        if (false === $criteriaSet->has('LightSaml\Resolver\Endpoint\Criteria\ServiceTypeCriteria')) {
             return $candidates;
         }
 
         $result = array();
         /** @var ServiceTypeCriteria $serviceTypeCriteria */
-        foreach ($criteriaSet->get(ServiceTypeCriteria::class) as $serviceTypeCriteria) {
+        foreach ($criteriaSet->get('LightSaml\Resolver\Endpoint\Criteria\ServiceTypeCriteria') as $serviceTypeCriteria) {
             foreach ($candidates as $endpointReference) {
                 $type = $serviceTypeCriteria->getServiceType();
                 if ($endpointReference->getEndpoint() instanceof $type) {


### PR DESCRIPTION
Using the static `::class` property to get the name of a class is only compatible with PHP 5.5, according to this StackOverflow article: http://stackoverflow.com/questions/29862558/unexpected-class-t-class-only-on-remote-not-in-local. This removes `::class` in favor of using `get_class()` for instantiated objects and full namespaced class string for uninstantiated objects, to make the bundle compatible with PHP 5.6.

Submitting similar PR for https://github.com/lightSAML/SymfonyBridgeBundle: https://github.com/lightSAML/SymfonyBridgeBundle/pull/15