### PR TITLE
Bugfix in LightSaml\Model\Protocol\Status

### DIFF
--- a/src/LightSaml/Model/Protocol/Status.php
+++ b/src/LightSaml/Model/Protocol/Status.php
@@ -31,7 +31,7 @@ class Status extends AbstractSamlModel
     public function __construct(StatusCode $statusCode = null, $message = null)
     {
         $this->statusCode = $statusCode;
-        $this->message = $message;
+        $this->statusMessage = $message;
     }
 
     /**


### PR DESCRIPTION
Replaced $this->message by $this->statusMessage in __contruct().