### PR TITLE
PHP 7.2 parameter must be an array|object that implements Countable

### DIFF
--- a/src/LightSaml/Resolver/Endpoint/Criteria/BindingCriteria.php
+++ b/src/LightSaml/Resolver/Endpoint/Criteria/BindingCriteria.php
@@ -20,7 +20,7 @@ class BindingCriteria implements CriteriaInterface
      *
      * @var int[]
      */
-    protected $bindings;
+    protected $bindings = [];
 
     /**
      * @param string[] $bindings Ordered by preference, first being most preferable, last least preferable


### PR DESCRIPTION
In BindingCriteria the property $bindings can be null. In this case, with php 7.2, we have a warning message as is expecting a countable on count(), line 42.