### PR TITLE
Fixed warning for PHP 7.2

### DIFF
--- a/src/LightSaml/Resolver/Endpoint/Criteria/BindingCriteria.php
+++ b/src/LightSaml/Resolver/Endpoint/Criteria/BindingCriteria.php
@@ -27,6 +27,8 @@ class BindingCriteria implements CriteriaInterface
      */
     public function __construct(array $bindings)
     {
+        $this->bindings = array();
+        
         foreach ($bindings as $binding) {
             $this->add($binding);
         }


### PR DESCRIPTION
Hi Team,

This is a fix for PHP 7.2 as it requires variable to be countable for counting.

![image](https://user-images.githubusercontent.com/7233258/33932343-b429c4f2-e02d-11e7-8ce6-38cacb447e6d.png)
