### PR TITLE
Adds Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,13 @@
     },
     "require": {
         "php": ">=5.5.1",
-        "robrichards/xmlseclibs": "~2.0|~3.0",
-        "symfony/http-foundation": "~2.3|~3.0",
-        "symfony/event-dispatcher": "~2.3|~3.0"
+        "robrichards/xmlseclibs": "~2.0|~3.0|~4.0",
+        "symfony/http-foundation": "~2.3|~3.0|~4.0",
+        "symfony/event-dispatcher": "~2.3|~3.0|~4.0"
     },
     "require-dev": {
-        "symfony/dom-crawler": "~2.3",
-        "symfony/css-selector": "~2.3",
+        "symfony/dom-crawler": "~2.3|~3.0|~4.0",
+        "symfony/css-selector": "~2.3|~3.0|~4.0",
         "pimple/pimple": "~3.0",
         "phpunit/phpunit": "~4.5",
         "monolog/monolog": "~1.3",


### PR DESCRIPTION
This PR makes it possible to use lightSAML with Symfony 4 (requirement for https://github.com/lightSAML/SpBundle/issues/62)