### PR TITLE
[TASK] Give concrete error messages in EntityDescriptor

### DIFF
--- a/src/LightSaml/Model/Metadata/EntityDescriptor.php
+++ b/src/LightSaml/Model/Metadata/EntityDescriptor.php
@@ -11,6 +11,7 @@
 
 namespace LightSaml\Model\Metadata;
 
+use LightSaml\Error\LightSamlException;
 use LightSaml\Helper;
 use LightSaml\Model\Context\DeserializationContext;
 use LightSaml\Model\Context\SerializationContext;
@@ -50,7 +51,18 @@ class EntityDescriptor extends Metadata
      */
     public static function load($filename)
     {
-        return self::loadXml(file_get_contents($filename));
+        $fileContent = file_get_contents($filename);
+        if ($fileContent === false) {
+            throw
+                new LightSamlException(
+                    sprintf(
+                        'Attempt to load file with URI "%s" results in an error. Consider verifying SSL certificates.',
+                        $filename
+                    ),
+                    1530105894244
+                );
+        }
+        return self::loadXml($fileContent);
     }
 
     /**
@@ -60,6 +72,13 @@ class EntityDescriptor extends Metadata
      */
     public static function loadXml($xml)
     {
+        if (empty($xml)) {
+            throw
+                new LightSamlException(
+                    'Given XML content to load is empty.',
+                    1530107980150
+                );
+        }
         $context = new DeserializationContext();
         $context->getDocument()->loadXML($xml);
         $ed = new self();

--- a/tests/LightSaml/Tests/Model/Metadata/EntityDescriptorTest.php
+++ b/tests/LightSaml/Tests/Model/Metadata/EntityDescriptorTest.php
@@ -21,6 +21,15 @@ use LightSaml\Tests\BaseTestCase;
 
 class EntityDescriptorTest extends BaseTestCase
 {
+    /**
+     * @expectedException \LightSaml\Error\LightSamlException
+     * @expectedExceptionMessage Given XML content to load is empty.
+     */
+    public function test_load_xml_throws_exception_on_empty_xml()
+    {
+        EntityDescriptor::loadXml('');
+    }
+
     public function test_serialization()
     {
         $ed = new EntityDescriptor();


### PR DESCRIPTION
This improves error reporting when unkowingly dealing
with an invalid URI that results into a boolean false
due to PHP's file_get_contents behavior especially
when dealing with invalid SSL URIs.