### PR TITLE
Fix typehints

### DIFF
--- a/src/LightSaml/Builder/EntityDescriptor/SimpleEntityDescriptorBuilder.php
+++ b/src/LightSaml/Builder/EntityDescriptor/SimpleEntityDescriptorBuilder.php
@@ -27,7 +27,7 @@ class SimpleEntityDescriptorBuilder implements EntityDescriptorProviderInterface
     /** @var string */
     protected $entityId;
 
-    /** @var string */
+    /** @var string|null */
     protected $acsUrl;
 
     /** @var string[] */

--- a/src/LightSaml/Model/Assertion/Conditions.php
+++ b/src/LightSaml/Model/Assertion/Conditions.php
@@ -186,7 +186,7 @@ class Conditions extends AbstractSamlModel
     }
 
     /**
-     * @param int|null $notOnOrAfter
+     * @param int|string|\DateTime|null $notOnOrAfter
      *
      * @return Conditions
      */


### PR DESCRIPTION
- SimpleEntityDescriptorBuilder `$acsUrl` is checked as `null === $this->acsUrl`, so should allow null type
- Conditions passes `$notOnOrAfter` to a helper which takes `int|string|\DateTime`, so it should match that type.