### PR TITLE
Fix param types in LightSaml\Model\Assertion\Conditions class

### DIFF
--- a/src/LightSaml/Model/Assertion/Conditions.php
+++ b/src/LightSaml/Model/Assertion/Conditions.php
@@ -142,7 +142,7 @@ class Conditions extends AbstractSamlModel
     }
 
     /**
-     * @param int|string|\DateTime|null $notBefore
+     * @param int|string|\DateTime $notBefore
      *
      * @return Conditions
      */
@@ -162,7 +162,7 @@ class Conditions extends AbstractSamlModel
     }
 
     /**
-     * @return int|null
+     * @return string|null
      */
     public function getNotBeforeString()
     {
@@ -186,7 +186,7 @@ class Conditions extends AbstractSamlModel
     }
 
     /**
-     * @param int|null $notOnOrAfter
+     * @param int|string|\DateTime $notOnOrAfter
      *
      * @return Conditions
      */


### PR DESCRIPTION
The `setNotBefore` and `setNotOnOrAfter` methods actually accept `int|string|\DateTime`, and do not accept null, since the argument is passed directly to `Helper::getTimestampFromValue()`.

This fixes an "Expected int, got DateTime" warning in PhpStorm when passing a `DateTime` instance to the `setNotOnOrAfter` method.

Also corrected the return type of `getNotBeforeString()`.