### PR TITLE
Preserve KeyName across key reloading.

### DIFF
--- a/src/LightSaml/Model/Assertion/EncryptedElementWriter.php
+++ b/src/LightSaml/Model/Assertion/EncryptedElementWriter.php
@@ -50,6 +50,7 @@ abstract class EncryptedElementWriter extends EncryptedElement
         $oldKey = $key;
         $key = new XMLSecurityKey($this->keyTransportEncryption, ['type' => 'public']);
         $key->loadKey($oldKey->key);
+        $key->name = $oldKey->name;
 
         $serializationContext = new SerializationContext();
         $object->serialize($serializationContext->getDocument(), $serializationContext);


### PR DESCRIPTION
Right now an encryption key's name (created via \LightSaml\Credential\KeyHelper) is lost in the \LightSaml\Model\Assertion\EncryptedElementWriter->encrypt() method.  It is lost because the key is reloaded at the top of the encrypt() method; I have added one extra line that will transfer the old key's name into the new key.