### PR TITLE
php73 and symfony5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
 
 matrix:
     include:

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "symfony/dom-crawler": "~2.3|~3.0|~4.0|~5.0",
         "symfony/css-selector": "~2.3|~3.0|~4.0|~5.0",
         "pimple/pimple": "~3.0",
-        "phpunit/phpunit": "7.5.20",
+        "phpunit/phpunit": "6.5.14",
         "monolog/monolog": "~1.3"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,13 @@
     },
     "require": {
         "php": ">=5.6",
-        "robrichards/xmlseclibs": "~2.0|~3.0|~4.0",
-        "symfony/http-foundation": "~2.3|~3.0|~4.0",
-        "symfony/event-dispatcher": "~2.3|~3.0|~4.0"
+        "robrichards/xmlseclibs": "~2.0|~3.0",
+        "symfony/http-foundation": "~2.3|~3.0|~4.0|~5.0",
+        "symfony/event-dispatcher": "~2.3|~3.0|~4.0|~5.0"
     },
     "require-dev": {
-        "symfony/dom-crawler": "~2.3|~3.0|~4.0",
-        "symfony/css-selector": "~2.3|~3.0|~4.0",
+        "symfony/dom-crawler": "~2.3|~3.0|~4.0|~5.0",
+        "symfony/css-selector": "~2.3|~3.0|~4.0|~5.0",
         "pimple/pimple": "~3.0",
         "phpunit/phpunit": ">=5.7",
         "monolog/monolog": "~1.3"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "symfony/dom-crawler": "~2.3|~3.0|~4.0|~5.0",
         "symfony/css-selector": "~2.3|~3.0|~4.0|~5.0",
         "pimple/pimple": "~3.0",
-        "phpunit/phpunit": ">=5.7",
+        "phpunit/phpunit": "7.5.20",
         "monolog/monolog": "~1.3"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "symfony/dom-crawler": "~2.3|~3.0|~4.0|~5.0",
         "symfony/css-selector": "~2.3|~3.0|~4.0|~5.0",
         "pimple/pimple": "~3.0",
-        "phpunit/phpunit": "6.5.14",
+        "phpunit/phpunit": ">=5.7 <8.0",
         "monolog/monolog": "~1.3"
     },
     "suggest": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,12 +10,11 @@
         convertWarningsToExceptions = "true"
         processIsolation            = "false"
         stopOnFailure               = "false"
-        syntaxCheck                 = "false"
         bootstrap                   = "autoload.php"
         >
 
     <logging>
-        <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
+        <log type="junit" target="build/logs/junit.xml"/>
     </logging>
 
     <testsuites>

--- a/src/LightSaml/Action/DispatchEventAction.php
+++ b/src/LightSaml/Action/DispatchEventAction.php
@@ -14,6 +14,7 @@ namespace LightSaml\Action;
 use LightSaml\Context\ContextInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 class DispatchEventAction implements ActionInterface
 {
@@ -29,7 +30,7 @@ class DispatchEventAction implements ActionInterface
      */
     public function __construct(EventDispatcherInterface $eventDispatcher, $event)
     {
-        $this->eventDispatcher = $eventDispatcher;
+        $this->eventDispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
         $this->event = $event;
     }
 
@@ -40,6 +41,6 @@ class DispatchEventAction implements ActionInterface
      */
     public function execute(ContextInterface $context)
     {
-        $this->eventDispatcher->dispatch($this->event, new GenericEvent($context));
+        $this->eventDispatcher->dispatch(new GenericEvent($context), $this->event);
     }
 }

--- a/src/LightSaml/Action/DispatchEventAction.php
+++ b/src/LightSaml/Action/DispatchEventAction.php
@@ -14,7 +14,6 @@ namespace LightSaml\Action;
 use LightSaml\Context\ContextInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 class DispatchEventAction implements ActionInterface
 {
@@ -30,7 +29,7 @@ class DispatchEventAction implements ActionInterface
      */
     public function __construct(EventDispatcherInterface $eventDispatcher, $event)
     {
-        $this->eventDispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
+        $this->eventDispatcher = $eventDispatcher;
         $this->event = $event;
     }
 

--- a/src/LightSaml/Binding/AbstractBinding.php
+++ b/src/LightSaml/Binding/AbstractBinding.php
@@ -48,7 +48,7 @@ abstract class AbstractBinding
     protected function dispatchReceive($messageString)
     {
         if ($this->eventDispatcher) {
-            $this->eventDispatcher->dispatch(Events::BINDING_MESSAGE_RECEIVED, new GenericEvent($messageString));
+            $this->eventDispatcher->dispatch(new GenericEvent($messageString), Events::BINDING_MESSAGE_RECEIVED);
         }
     }
 
@@ -58,7 +58,7 @@ abstract class AbstractBinding
     protected function dispatchSend($messageString)
     {
         if ($this->eventDispatcher) {
-            $this->eventDispatcher->dispatch(Events::BINDING_MESSAGE_SENT, new GenericEvent($messageString));
+            $this->eventDispatcher->dispatch(new GenericEvent($messageString), Events::BINDING_MESSAGE_SENT);
         }
     }
 

--- a/tests/LightSaml/Tests/Action/DispatchEventActionTest.php
+++ b/tests/LightSaml/Tests/Action/DispatchEventActionTest.php
@@ -33,8 +33,8 @@ class DispatchEventActionTest extends BaseTestCase
         $eventDispatcherMock->expects($this->once())
             ->method('dispatch')
             ->with(
-                $this->equalTo($expectedEventName),
-                $this->isInstanceOf(GenericEvent::class)
+                $this->isInstanceOf(GenericEvent::class),
+                $this->equalTo($expectedEventName)
             );
 
         $action->execute($context);

--- a/tests/LightSaml/Tests/Functional/Binding/HttpPostBindingFunctionalTest.php
+++ b/tests/LightSaml/Tests/Functional/Binding/HttpPostBindingFunctionalTest.php
@@ -29,12 +29,13 @@ class HttpPostBindingFunctionalTest extends BaseTestCase
         $eventDispatcherMock = $this->getEventDispatcherMock();
         $eventDispatcherMock->expects($this->once())
             ->method('dispatch')
-            ->willReturnCallback(function ($name, GenericEvent $event) {
+            ->willReturnCallback(function (GenericEvent $event, $name) {
                 $this->assertEquals(Events::BINDING_MESSAGE_SENT, $name);
                 $this->assertNotEmpty($event->getSubject());
                 $doc = new \DOMDocument();
                 $doc->loadXML($event->getSubject());
                 $this->assertEquals('AuthnRequest', $doc->firstChild->localName);
+                return $event;
             });
 
         $biding->setEventDispatcher($eventDispatcherMock);
@@ -99,12 +100,13 @@ class HttpPostBindingFunctionalTest extends BaseTestCase
         $eventDispatcherMock = $this->getEventDispatcherMock();
         $eventDispatcherMock->expects($this->once())
             ->method('dispatch')
-            ->willReturnCallback(function ($name, GenericEvent $event) {
+            ->willReturnCallback(function (GenericEvent $event, $name) {
                 $this->assertEquals(Events::BINDING_MESSAGE_RECEIVED, $name);
                 $this->assertNotEmpty($event->getSubject());
                 $doc = new \DOMDocument();
                 $doc->loadXML($event->getSubject());
                 $this->assertEquals('AuthnRequest', $doc->firstChild->localName);
+                return $event;
             });
 
         $binding->setEventDispatcher($eventDispatcherMock);

--- a/tests/LightSaml/Tests/Functional/Binding/HttpRedirectBindingFunctionalTest.php
+++ b/tests/LightSaml/Tests/Functional/Binding/HttpRedirectBindingFunctionalTest.php
@@ -32,12 +32,13 @@ class HttpRedirectBindingFunctionalTest extends BaseTestCase
         $eventDispatcherMock = $this->getEventDispatcherMock();
         $eventDispatcherMock->expects($this->once())
             ->method('dispatch')
-            ->willReturnCallback(function ($name, GenericEvent $event) {
+            ->willReturnCallback(function (GenericEvent $event, $name) {
                 $this->assertEquals(Events::BINDING_MESSAGE_SENT, $name);
                 $this->assertNotEmpty($event->getSubject());
                 $doc = new \DOMDocument();
                 $doc->loadXML($event->getSubject());
                 $this->assertEquals('AuthnRequest', $doc->firstChild->localName);
+                return $event;
             });
 
         $biding->setEventDispatcher($eventDispatcherMock);
@@ -122,12 +123,13 @@ class HttpRedirectBindingFunctionalTest extends BaseTestCase
         $eventDispatcherMock = $this->getEventDispatcherMock();
         $eventDispatcherMock->expects($this->once())
             ->method('dispatch')
-            ->willReturnCallback(function ($name, GenericEvent $event) {
+            ->willReturnCallback(function (GenericEvent $event, $name) {
                 $this->assertEquals(Events::BINDING_MESSAGE_RECEIVED, $name);
                 $this->assertNotEmpty($event->getSubject());
                 $doc = new \DOMDocument();
                 $doc->loadXML($event->getSubject());
                 $this->assertEquals('AuthnRequest', $doc->firstChild->localName);
+                return $event;
             });
 
         $binding->setEventDispatcher($eventDispatcherMock);


### PR DESCRIPTION
Small change set which minimally resolves php73 / symfony5 support.
See build: https://travis-ci.org/github/lightSAML/lightSAML/builds/722946552

There's some other branches where folks have done the same stuff, just with more changes then I wanted at once.
* https://github.com/4Labs/lightSAML
* https://github.com/lightSAML/lightSAML/pull/129/files / https://github.com/thephplab/lightsaml