### PR TITLE
style: fix typo in autoload.php

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -3,6 +3,6 @@
 // if library is in dev environement with its own vendor, include its autoload
 if(file_exists(__DIR__ . '/vendor'))
     require_once __DIR__ . '/vendor/autoload.php';
-// if library is in vendor of another project, include the global autolaod
+// if library is in vendor of another project, include the global autoload
 else
     require_once __DIR__ . '/../../autoload.php';


### PR DESCRIPTION
### Reasons for the changes:

There was a typo in the comment.