### PR TITLE
Update SsoSpSendAuthnRequestProfileBuilder.php

### DIFF
--- a/src/LightSaml/Builder/Profile/WebBrowserSso/Sp/SsoSpSendAuthnRequestProfileBuilder.php
+++ b/src/LightSaml/Builder/Profile/WebBrowserSso/Sp/SsoSpSendAuthnRequestProfileBuilder.php
@@ -83,7 +83,7 @@ class SsoSpSendAuthnRequestProfileBuilder extends AbstractProfileBuilder
     {
         $trustOptions = $this->container->getPartyContainer()->getTrustOptionsStore()->get($this->idpEntityId) ?: new TrustOptions();
 
-        $wantAuthnRequestsSigned = $idpEd->getFirstIdpSsoDescriptor()->getWantAuthnRequestsSigned();
+        $wantAuthnRequestsSigned = $idpEd->getFirstIdpSsoDescriptor() ? $idpEd->getFirstIdpSsoDescriptor()->getWantAuthnRequestsSigned() : null;
 
         if (null !== $wantAuthnRequestsSigned) {
             $trustOptions->setSignAuthnRequest($wantAuthnRequestsSigned);


### PR DESCRIPTION
Get trust options: Fixed a null exception if the first IDP SSO descriptor is empty.